### PR TITLE
Support get-config

### DIFF
--- a/models/test.xml
+++ b/models/test.xml
@@ -11,6 +11,7 @@
         <VALUE name="false" value="false"/>
       </NODE>
       <NODE name="priority" mode="rw" help="integer"/>
+      <NODE name="lastmod" mode="r" help="timestamp"/>
     </NODE>
     <NODE name="state" help="State">
       <NODE name="counter" mode="r" default="0" help="uint32"/>

--- a/netconf.c
+++ b/netconf.c
@@ -310,7 +310,7 @@ get_full_tree ()
 }
 
 static bool
-handle_get (struct netconf_session *session, xmlNode * rpc)
+handle_get (struct netconf_session *session, xmlNode * rpc, gboolean config_only)
 {
     xmlNode *action = xmlFirstElementChild (rpc);
     xmlNode *node;
@@ -322,6 +322,11 @@ handle_get (struct netconf_session *session, xmlNode * rpc)
 
     if (apteryx_netconf_verbose)
         schflags |= SCH_F_DEBUG;
+
+    if (config_only)
+    {
+        schflags |= SCH_F_CONFIG;
+    }
 
     /* Parse options */
     for (node = xmlFirstElementChild (action); node; node = xmlNextElementSibling (node))
@@ -376,7 +381,7 @@ handle_get (struct netconf_session *session, xmlNode * rpc)
             }
             free (attr);
         }
-        //TODO - Parse with-defaults 
+        //TODO - Parse with-defaults
     }
 
     /* Query database */
@@ -621,11 +626,15 @@ netconf_handle_session (int fd)
             g_free (message);
             break;
         }
-        else if (g_strcmp0 ((char *) child->name, "get") == 0 ||
-                 g_strcmp0 ((char *) child->name, "get-config") == 0)
+        else if (g_strcmp0 ((char *) child->name, "get") == 0)
         {
             VERBOSE ("Handle RPC %s\n", (char *) child->name);
-            handle_get (session, rpc);
+            handle_get (session, rpc, false);
+        }
+        else if (g_strcmp0 ((char *) child->name, "get-config") == 0)
+        {
+            VERBOSE ("Handle RPC %s\n", (char *) child->name);
+            handle_get (session, rpc, true);
         }
         else if (g_strcmp0 ((char *) child->name, "edit-config") == 0)
         {

--- a/test_netconf.py
+++ b/test_netconf.py
@@ -20,6 +20,7 @@ db_default = [
     ('/test/settings/debug', 'enable'),
     ('/test/settings/enable', 'true'),
     ('/test/settings/priority', '1'),
+    ('/test/settings/lastmod', '1567898765'),
     ('/test/state/counter', '42'),
     ('/test/animals/animal/cat/name', 'cat'),
     ('/test/animals/animal/cat/type', 'big'),
@@ -166,6 +167,7 @@ def test_get_subtree_trunk():
             <debug>enable</debug>
             <enable>true</enable>
             <priority>1</priority>
+            <lastmod>1567898765</lastmod>
         </settings>
     </test>
 </nc:data>
@@ -505,6 +507,7 @@ def test_get_xpath_trunk():
             <debug>enable</debug>
             <enable>true</enable>
             <priority>1</priority>
+            <lastmod>1567898765</lastmod>
         </settings>
     </test>
 </nc:data>
@@ -614,14 +617,14 @@ def test_get_config_unsupported_datastore():
     m.close_session()
 
 
-@pytest.mark.skip(reason="does not work yet")
 def test_get_config_no_state():
     m = connect()
     xml = m.get_config(source='running').data
     print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
     # Full tree should be returned with config only
     assert xml.find('./{*}test/{*}settings/{*}debug').text == 'enable'
-    assert xml.find('./{*}test/{*}state/{*}counter').text != '42'
+    assert xml.find('./{*}test/{*}settings/{*}lastmod') is None
+    assert xml.find('./{*}test/{*}state/{*}counter') is None
     assert xml.find('./{*}test/{*}animals/{*}animal/{*}name').text == 'cat'
     # Ignore the rest!
     m.close_session()
@@ -766,7 +769,7 @@ def test_edit_config_delete_multi():
     print(response)
     xml = m.get(filter=('xpath', '/test/settings')).data
     print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
-    assert etree.XPath("//text()")(xml) == ['enable']
+    assert etree.XPath("//text()")(xml) == ['enable', '1567898765']
     m.close_session()
 
 
@@ -827,8 +830,9 @@ def test_edit_config_merge_delete():
     print(response)
     xml = m.get(filter=('xpath', '/test/settings')).data
     print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
-    assert etree.XPath("//text()")(xml) == ['enable', 'false']
+    assert etree.XPath("//text()")(xml) == ['enable', 'false', '1567898765']
     m.close_session()
+
 
 # TODO EDIT-CONFIG (operation:default=merge)
     #  replace:  The configuration data identified by the element


### PR DESCRIPTION
The get-config RPC now only return config information. Stop skipping
the test which showed this failing, and change the test schema to test
another case. Fix existing tests for new schema.