### PR TITLE
Add reporting for xpath and writable-running capabilities

### DIFF
--- a/netconf.c
+++ b/netconf.c
@@ -255,8 +255,10 @@ handle_hello (struct netconf_session *session)
     node = xmlNewChild (root, NULL, BAD_CAST "nc:capabilities", NULL);
     child = xmlNewChild (node, NULL, BAD_CAST "nc:capability", NULL);
     xmlNodeSetContent (child, BAD_CAST "urn:ietf:params:netconf:base:1.1");
-    // child = xmlNewChild (node, NULL, BAD_CAST "nc:capability", NULL);
-    // xmlNodeSetContent (child, BAD_CAST "urn:ietf:params:netconf:capability:xpath:1.0");
+    child = xmlNewChild (node, NULL, BAD_CAST "nc:capability", NULL);
+    xmlNodeSetContent (child, BAD_CAST "urn:ietf:params:netconf:capability:xpath:1.0");
+    child = xmlNewChild (node, NULL, BAD_CAST "nc:capability", NULL);
+    xmlNodeSetContent (child, BAD_CAST "urn:ietf:params:netconf:capability:writable-running:1.0");
     child = xmlNewChild (node, NULL, BAD_CAST "nc:capability", NULL);
     xmlNodeSetContent (child,
                        BAD_CAST "urn:ietf:params:netconf:capability:with-defaults:1.0");

--- a/test_netconf.py
+++ b/test_netconf.py
@@ -86,9 +86,9 @@ def test_server_capabilities():
     for capability in m.server_capabilities:
         print("Capability: %s" % capability.split('?')[0])
     assert ":base" in m.server_capabilities
-    # assert ":writable-running" in m.server_capabilities
+    assert ":writable-running" in m.server_capabilities
     # assert ":startup" in m.server_capabilities
-    # assert ":xpath" in m.server_capabilities
+    assert ":xpath" in m.server_capabilities
     assert ":with-defaults" in m.server_capabilities
 
     assert ":candidate" not in m.server_capabilities


### PR DESCRIPTION
We were not reporting these in the hello message even though we support
them. Change the test case to reflect this.