### PR TITLE
Support using a subset of the available XML models for Netconf

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -53,7 +53,8 @@ extern gboolean apteryx_netconf_verbose;
 extern GMainLoop *g_loop;
 
 /* Netconf routines */
-gboolean netconf_init (const char *path, const char *cp, const char *rm);
+gboolean netconf_init (const char *path, const char *supported,
+                       const char *cp, const char *rm);
 void *netconf_handle_session (int fd);
 void netconf_shutdown (void);
 

--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@ gboolean apteryx_netconf_debug = FALSE;
 gboolean apteryx_netconf_verbose = FALSE;
 static gboolean background = FALSE;
 static gchar *models_path = "./";
+static gchar *supported = NULL;
 static gchar *unix_path = "/tmp/apteryx-netconf";
 static gchar *cp_cmd = NULL;
 static gchar *rm_cmd = NULL;
@@ -85,6 +86,8 @@ static GOptionEntry entries[] = {
     {"background", 'b', 0, G_OPTION_ARG_NONE, &background, "Background", NULL},
     {"models", 'm', 0, G_OPTION_ARG_STRING, &models_path,
      "Path to models(defaults to \"./\")", NULL},
+    {"supported", 's', 0, G_OPTION_ARG_STRING, &supported,
+     "Name of file containing a list of supported models", NULL},
     {"unix", 'u', 0, G_OPTION_ARG_STRING, &unix_path,
      "Listen on unix socket (defaults to /tmp/apteryx-netconf.sock)", NULL},
     {"copy", 'c', 0, G_OPTION_ARG_STRING, &cp_cmd,
@@ -119,7 +122,7 @@ main (int argc, char *argv[])
 
     /* Initialization */
     apteryx_init (apteryx_netconf_verbose);
-    if (!netconf_init (models_path, cp_cmd, rm_cmd))
+    if (!netconf_init (models_path, supported, cp_cmd, rm_cmd))
     {
         g_error ("Failed to load models from \"%s\"\n", models_path);
     }

--- a/netconf.c
+++ b/netconf.c
@@ -1072,10 +1072,11 @@ netconf_handle_session (int fd)
 }
 
 gboolean
-netconf_init (const char *path, const char *cp, const char *rm)
+netconf_init (const char *path, const char *supported,
+              const char *cp, const char *rm)
 {
     /* Load Data Models */
-    g_schema = sch_load (path);
+    g_schema = sch_load_with_model_list_filename (path, supported);
     if (!g_schema)
     {
         return false;


### PR DESCRIPTION
This changes allows a configuration file to be specified that contains a list of the model names to be loaded at start up. This gives finer control of the models loaded netconf.