### PR TITLE
Fix crash on shutdown

### DIFF
--- a/main.c
+++ b/main.c
@@ -140,6 +140,9 @@ main (int argc, char *argv[])
     /* Cleanup Unix socket */
     unlink (unix_path);
 
+    /* Wait until the thread pool is done */
+    g_thread_join(g_thread);
+
     /* Shutdown */
     netconf_shutdown ();
     apteryx_shutdown ();

--- a/netconf.c
+++ b/netconf.c
@@ -48,14 +48,17 @@ static GSList *open_sessions_list = NULL;
 static void
 free_open_sessions_list (void)
 {
-    GSList *iter = g_slist_last (open_sessions_list);
-    while (iter)
+    if (open_sessions_list)
     {
-        open_sessions_list = g_slist_remove (open_sessions_list, iter);
-        g_free (iter->data);
-        iter = g_slist_last (open_sessions_list);
+        for (guint i = 0; i < g_slist_length (open_sessions_list); i++)
+        {
+            struct netconf_session *nc_session =
+                (struct netconf_session *) g_slist_nth_data (open_sessions_list, i);
+            if (nc_session)
+                g_free (nc_session);
+        }
+        g_slist_free (open_sessions_list);
     }
-    g_slist_free (open_sessions_list);
 }
 
 /* Remove specified netconf session from open_sessions_list */


### PR DESCRIPTION
If a netconf rpc is active when the server is shut down, then depending on timing, a crash can occur. The crash is due to the sessions and g_schema being deleted before an active thread in the thread pool is completed. An issue with the routine free_open_sessions has also been fixed.