### PR TITLE
Fix an issue stopping netconf from shutting down cleanly

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -53,6 +53,7 @@ extern gboolean apteryx_netconf_verbose;
 extern GMainLoop *g_loop;
 
 /* Netconf routines */
+void netconf_close_open_sessions (void);
 gboolean netconf_init (const char *path, const char *supported,
                        const char *cp, const char *rm);
 void *netconf_handle_session (int fd);

--- a/main.c
+++ b/main.c
@@ -140,6 +140,9 @@ main (int argc, char *argv[])
     /* Cleanup Unix socket */
     unlink (unix_path);
 
+    /* Wait until the thread pool is done */
+    g_thread_join(g_thread);
+
     /* Shutdown */
     netconf_shutdown ();
     apteryx_shutdown ();

--- a/main.c
+++ b/main.c
@@ -140,9 +140,6 @@ main (int argc, char *argv[])
     /* Cleanup Unix socket */
     unlink (unix_path);
 
-    /* Wait until the thread pool is done */
-    g_thread_join(g_thread);
-
     /* Shutdown */
     netconf_shutdown ();
     apteryx_shutdown ();

--- a/models/rfc6243_example.xml
+++ b/models/rfc6243_example.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<MODULE xmlns="http://example.com/ns/interfaces" xmlns:exam="http://example.com/ns/interfaces" model="example" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/alliedtelesis/apteryx-xml https://github.com/alliedtelesis/apteryx-xml/releases/download/v1.2/apteryx.xsd">
+  <NODE name="interfaces" help="Example interfaces group">
+    <NODE name="interface" help="Example interface entry">
+      <NODE name="*" help="The interface entry with key name">
+        <NODE name="name" mode="rw" help="The administrative name of the interface. This is an identifier that is only unique within the scope of this list, and only within a specific server."/>
+        <NODE name="mtu" mode="rw" default="1500" help="The maximum transmission unit (MTU) value assigned to this interface."/>
+        <NODE name="status" mode="r" default="up" help="The current status of this interface.">
+          <VALUE name="up" value="up"/>
+          <VALUE name="waking up" value="waking up"/>
+          <VALUE name="not feeling so good" value="not feeling so good"/>
+          <VALUE name="better check it out" value="better check it out"/>
+           <VALUE name="better call for help" value="better call for help"/>
+        </NODE>
+      </NODE>
+    </NODE>
+  </NODE>
+</MODULE>

--- a/models/rfc6243_example.yang
+++ b/models/rfc6243_example.yang
@@ -1,0 +1,53 @@
+module example {
+
+     namespace "http://example.com/ns/interfaces";
+
+     prefix exam;
+
+     typedef status-type {
+        description "Interface status";
+        type enumeration {
+          enum up;
+          enum 'waking up';
+          enum 'not feeling so good';
+          enum 'better check it out';
+          enum 'better call for help';
+        }
+        default up;
+     }
+
+     container interfaces {
+         description "Example interfaces group";
+
+         list interface {
+           description "Example interface entry";
+           key name;
+
+           leaf name {
+             description
+               "The administrative name of the interface.
+                This is an identifier that is only unique
+                within the scope of this list, and only
+                within a specific server.";
+             type string {
+               length "1 .. max";
+             }
+           }
+
+           leaf mtu {
+             description
+               "The maximum transmission unit (MTU) value assigned to
+                this interface.";
+             type uint32;
+             default 1500;
+           }
+
+           leaf status {
+             description
+               "The current status of this interface.";
+             type status-type;
+             config false;
+           }
+         }
+       }
+     }

--- a/netconf.c
+++ b/netconf.c
@@ -48,14 +48,17 @@ static GSList *open_sessions_list = NULL;
 static void
 free_open_sessions_list (void)
 {
-    GSList *iter = g_slist_last (open_sessions_list);
-    while (iter)
+    if (open_sessions_list)
     {
-        open_sessions_list = g_slist_remove (open_sessions_list, iter);
-        g_free (iter->data);
-        iter = g_slist_last (open_sessions_list);
+        for (guint i = 0; i < g_slist_length (open_sessions_list); i++)
+        {
+            struct netconf_session *nc_session =
+                (struct netconf_session *) g_slist_nth_data (open_sessions_list, i);
+            if (nc_session)
+                g_free (nc_session);
+        }
+        g_slist_free (open_sessions_list);
     }
-    g_slist_free (open_sessions_list);
 }
 
 /* Remove specified netconf session from open_sessions_list */

--- a/netconf.c
+++ b/netconf.c
@@ -44,9 +44,9 @@ static uint32_t netconf_session_id = 1;
 /* Maintain a list of open sessions */
 static GSList *open_sessions_list = NULL;
 
-/* Free open_sessions_list */
-static void
-free_open_sessions_list (void)
+/* Close open sessions */
+void
+netconf_close_open_sessions (void)
 {
     if (open_sessions_list)
     {
@@ -54,10 +54,12 @@ free_open_sessions_list (void)
         {
             struct netconf_session *nc_session =
                 (struct netconf_session *) g_slist_nth_data (open_sessions_list, i);
-            if (nc_session)
-                g_free (nc_session);
+            if (nc_session->fd >= 0)
+            {
+                close (nc_session->fd);
+                nc_session->fd = -1;
+            }
         }
-        g_slist_free (open_sessions_list);
     }
 }
 
@@ -1049,7 +1051,11 @@ create_session (int fd)
 static void
 destroy_session (struct netconf_session *session)
 {
-    close (session->fd);
+    if (session->fd >= 0)
+    {
+        close (session->fd);
+        session->fd = -1;
+    }
 
     if (session->id == running_ds_lock.nc_sess.id)
     {
@@ -1276,7 +1282,4 @@ netconf_shutdown (void)
     /* Cleanup datamodels */
     if (g_schema)
         sch_free (g_schema);
-
-    /* Free objects */
-    free_open_sessions_list ();
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,18 @@ db_default = [
     ('/t2:test/settings/priority', '2'),
     # Non-default namespace augmented path
     ('/t2:test/settings/speed', '2'),
+    # Data for with-defaults testing
+    ('/interfaces/interface/eth0/name', 'eth0'),
+    ('/interfaces/interface/eth0/mtu', '8192'),
+    ('/interfaces/interface/eth0/status', 'up'),
+    ('/interfaces/interface/eth1/name', 'eth1'),
+    ('/interfaces/interface/eth1/status', 'up'),
+    ('/interfaces/interface/eth2/name', 'eth2'),
+    ('/interfaces/interface/eth2/mtu', '9000'),
+    ('/interfaces/interface/eth2/status', 'not feeling so good'),
+    ('/interfaces/interface/eth3/name', 'eth3'),
+    ('/interfaces/interface/eth3/mtu', '1500'),
+    ('/interfaces/interface/eth3/status', 'waking up'),
 ]
 
 
@@ -129,6 +141,22 @@ def _get_test_with_filter(f_value, expected=None, f_type='subtree'):
     """
     m = connect()
     xml = m.get(filter=(f_type, f_value)).data
+    print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
+    if expected:
+        expected = toXML(expected)
+        assert diffXML(xml, expected) is None
+    m.close_session()
+    return xml
+
+
+def _get_test_with_defaults_and_filter(f_value, w_d_value, expected=None, f_type='subtree'):
+    """
+    Perform a get with the given filter, which can be of type 'subtree' or 'xpath'. If expectede
+    respose is given, assert that it was the same as the response from the get. Return the response
+    so the caller can perform its own tests.
+    """
+    m = connect()
+    xml = m.get(filter=(f_type, f_value), with_defaults=(w_d_value)).data
     print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
     if expected:
         expected = toXML(expected)

--- a/tests/test_with_defaults.py
+++ b/tests/test_with_defaults.py
@@ -1,0 +1,183 @@
+from conftest import _get_test_with_defaults_and_filter
+
+
+def test_with_defaults_explicit():
+    with_defaults = 'explicit'
+    xpath = '/interfaces'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces>
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth1</name>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <mtu>1500</mtu>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(xpath, with_defaults, expected, f_type='xpath')
+
+
+def test_with_defaults_report_all():
+    with_defaults = 'report-all'
+    xpath = '/interfaces'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces>
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth1</name>
+            <mtu>1500</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <mtu>1500</mtu>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(xpath, with_defaults, expected, f_type='xpath')
+
+
+def test_with_defaults_trim():
+    with_defaults = 'trim'
+    xpath = '/interfaces'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces>
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+        </interface>
+        <interface>
+            <name>eth1</name>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(xpath, with_defaults, expected, f_type='xpath')
+
+
+def test_with_defaults_explicit_subtree():
+    with_defaults = 'explicit'
+    select = '<interfaces></interfaces>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces>
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth1</name>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <mtu>1500</mtu>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)
+
+
+def test_with_defaults_report_all_subtree():
+    with_defaults = 'report-all'
+    select = '<interfaces></interfaces>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces>
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth1</name>
+            <mtu>1500</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <mtu>1500</mtu>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)
+
+
+def test_with_defaults_trim_subtree():
+    with_defaults = 'trim'
+    select = '<interfaces></interfaces>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces>
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+        </interface>
+        <interface>
+            <name>eth1</name>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)


### PR DESCRIPTION
The new exception shutdown strategy is to shut down the accept socket,
then close any open session sockets. As the worker threads handling the
open sessions close down they cleanup any remaining memory used by
the session. Hence on process termination, an additional explicit
cleanup routine for open sessions is not required.