### PR TITLE
Fix an issue stopping netconf from shutting down cleanly

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -53,6 +53,7 @@ extern gboolean apteryx_netconf_verbose;
 extern GMainLoop *g_loop;
 
 /* Netconf routines */
+void netconf_close_open_sessions (void);
 gboolean netconf_init (const char *path, const char *supported,
                        const char *cp, const char *rm);
 void *netconf_handle_session (int fd);


### PR DESCRIPTION
The new exception shutdown strategy is to shut down the accept socket, then close any open session sockets. As the worker threads handling the open sessions close down they cleanup any remaining memory used by the session. Hence on process termination, an additional explicit cleanup routine for open sessions is not required.