### PR TITLE
Add support for the logging of selected events in Netconf.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
 bin_PROGRAMS = apteryx-netconf
-apteryx_netconf_SOURCES = main.c netconf.c
+apteryx_netconf_SOURCES = main.c netconf.c logging.c
 apteryx_netconf_CFLAGS = @APTERYX_XML_CFLAGS@ @LIBXML2_CFLAGS@ @APTERYX_CFLAGS@ @GLIB_CFLAGS@
 apteryx_netconf_LDADD = @APTERYX_XML_LIBS@ @LIBXML2_LIBS@ @APTERYX_LIBS@ @GLIB_LIBS@

--- a/internal.h
+++ b/internal.h
@@ -43,20 +43,41 @@ extern gboolean apteryx_netconf_verbose;
         syslog (LOG_DEBUG, fmt, ## args); \
         printf (fmt, ## args); \
     }
+#define NOTICE(fmt, args...) \
+    { \
+        syslog (LOG_NOTICE, fmt, ## args); \
+        printf (fmt, ## args); \
+    }
 #define ERROR(fmt, args...) \
     { \
         syslog (LOG_CRIT, fmt, ## args); \
         fprintf (stderr, fmt, ## args); \
     }
 
+typedef enum
+{
+    LOG_NONE                    = 0,
+    LOG_EDIT_CONFIG             = (1 << 0),  /* Log edit-config requests */
+    LOG_GET                     = (1 << 1),  /* Log get requests */
+    LOG_GET_CONFIG              = (1 << 2),  /* Log get-config requests */
+    LOG_KILL_SESSION            = (1 << 3),  /* Log kill-session requests */
+    LOG_LOCK                    = (1 << 4),  /* Log lock requests */
+    LOG_UNLOCK                  = (1 << 5),  /* Log unlock requests */
+} logging_flags;
+
 /* Main loop */
 extern GMainLoop *g_loop;
 
 /* Netconf routines */
 void netconf_close_open_sessions (void);
-gboolean netconf_init (const char *path, const char *supported,
+gboolean netconf_init (const char *path, const char *supported, const char *logging,
                        const char *cp, const char *rm);
 void *netconf_handle_session (int fd);
 void netconf_shutdown (void);
+
+/* Logging routines */
+int netconf_logging_init (const char *path, const char *logging);
+void netconf_logging_shutdown (void);
+bool netconf_logging_test_flag (int flag);
 
 #endif /* _INTERNAL_H_ */

--- a/logging.c
+++ b/logging.c
@@ -1,0 +1,170 @@
+/**
+ * @file logging.c
+ * Handler of the logging configuration file
+ *
+ * Copyright 2023, Allied Telesis Labs New Zealand, Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library. If not, see <http://www.gnu.org/licenses/>
+ */
+#include "internal.h"
+#include <sys/inotify.h>
+
+#define READ_BUF_SIZE 512
+
+static int inotify_fd = -1;
+
+/* Logging flags */
+static logging_flags log_flags = LOG_NONE;
+
+static GIOChannel *channel = NULL;
+static char *logging_filename = NULL;
+
+static int
+load_logging_options (void)
+{
+    FILE *fp = NULL;
+    gchar **split;
+    char *buf;
+    int count;
+    int i;
+    logging_flags flags = LOG_NONE;
+    int ret = 0;
+
+    buf = g_malloc0 (READ_BUF_SIZE);
+    fp = fopen (logging_filename, "r");
+    if (fp && buf)
+    {
+        if (fgets (buf, READ_BUF_SIZE, fp) != NULL)
+        {
+            /* Remove any trailing LF */
+            buf[strcspn(buf, "\n")] = '\0';
+            split = g_strsplit (buf, " ", 6);
+            count = g_strv_length (split);
+            for (i = 0; i < count; i++)
+            {
+                if (g_strcmp0 (split[i], "edit-config") == 0)
+                    flags |= LOG_EDIT_CONFIG;
+                else if (g_strcmp0 (split[i], "get") == 0)
+                    flags |= LOG_GET;
+                else if (g_strcmp0 (split[i], "get-config") == 0)
+                    flags |= LOG_GET_CONFIG;
+                else if (g_strcmp0 (split[i], "kill-session") == 0)
+                    flags |= LOG_KILL_SESSION;
+                else if (g_strcmp0 (split[i], "lock") == 0)
+                    flags |= LOG_LOCK;
+                else if (g_strcmp0 (split[i], "unlock") == 0)
+                    flags |= LOG_UNLOCK;
+            }
+            g_strfreev (split);
+        }
+        fclose (fp);
+    }
+    else
+    {
+        ret = -1;
+    }
+    g_free (buf);
+    log_flags = flags;
+
+    return ret;
+}
+
+/**
+ * Handles an inotify event indicating that the logging options file may have
+ * been modified and reloads the logging options in the file if necessary
+ */
+static int
+logging_file_update (void)
+{
+    char *buf;
+    int len;
+    int ret = -1;
+
+    /* Got a notify event informing the logging file has been modified */
+    if (inotify_fd >= 0)
+    {
+        buf = g_malloc0 (READ_BUF_SIZE);
+        len = read (inotify_fd, buf, READ_BUF_SIZE);
+        if (len)
+        {
+            ret = load_logging_options ();
+        }
+        g_free (buf);
+    }
+
+    return ret;
+}
+
+static gboolean
+logging_options_reload (GIOChannel *source, GIOCondition condition, gpointer data)
+{
+    logging_file_update ();
+    return TRUE;
+}
+
+static int
+logging_open_inotify (void)
+{
+    if (inotify_fd < 0)
+    {
+        /* inotify doesn't tell us about creation of the tracelog_control file
+         * unless we listen to inotify events for the whole directory */
+        inotify_fd = inotify_init ();
+        inotify_add_watch (inotify_fd, logging_filename,
+                           IN_MODIFY | IN_DELETE | IN_MOVE);
+    }
+
+    return inotify_fd;
+}
+
+bool
+netconf_logging_test_flag (int flag)
+{
+    return (log_flags & flag) != 0;
+}
+
+void
+netconf_logging_shutdown (void)
+{
+    if (inotify_fd >= 0)
+        close (inotify_fd);
+
+    if (channel)
+        g_io_channel_shutdown (channel, false, NULL);
+
+    if (logging_filename)
+        g_free (logging_filename);
+}
+
+int
+netconf_logging_init (const char *path, const char *logging)
+{
+    if (!path || !logging)
+        return -1;
+
+    logging_filename = g_strdup_printf ("%s/%s", path, logging);
+
+    /* Read the current setting */
+    if (load_logging_options () < 0)
+        return -1;
+
+    /* Add an inotify watch for logging changes */
+    if (logging_open_inotify () < 0)
+        return -1;
+
+    channel = g_io_channel_unix_new (logging_open_inotify ());
+    g_io_add_watch (channel, G_IO_IN, logging_options_reload, NULL);
+
+    return 0;
+}

--- a/main.c
+++ b/main.c
@@ -28,6 +28,7 @@ gboolean apteryx_netconf_verbose = FALSE;
 static gboolean background = FALSE;
 static gchar *models_path = "./";
 static gchar *supported = NULL;
+static gchar *logging = NULL;
 static gchar *unix_path = "/tmp/apteryx-netconf";
 static gchar *cp_cmd = NULL;
 static gchar *rm_cmd = NULL;
@@ -93,7 +94,9 @@ static GOptionEntry entries[] = {
     {"models", 'm', 0, G_OPTION_ARG_STRING, &models_path,
      "Path to models(defaults to \"./\")", NULL},
     {"supported", 's', 0, G_OPTION_ARG_STRING, &supported,
-     "Name of file containing a list of supported models", NULL},
+     "Name of a file containing a list of supported models", NULL},
+    {"logging", 'l', 0, G_OPTION_ARG_STRING, &logging,
+     "Name of a file containing a list of events to log", NULL},
     {"unix", 'u', 0, G_OPTION_ARG_STRING, &unix_path,
      "Listen on unix socket (defaults to /tmp/apteryx-netconf.sock)", NULL},
     {"copy", 'c', 0, G_OPTION_ARG_STRING, &cp_cmd,
@@ -128,7 +131,7 @@ main (int argc, char *argv[])
 
     /* Initialization */
     apteryx_init (apteryx_netconf_verbose);
-    if (!netconf_init (models_path, supported, cp_cmd, rm_cmd))
+    if (!netconf_init (models_path, supported, logging, cp_cmd, rm_cmd))
     {
         g_error ("Failed to load models from \"%s\"\n", models_path);
     }

--- a/models/netconf-logging-options
+++ b/models/netconf-logging-options
@@ -1,0 +1,1 @@
+edit-config get get-config kill-session lock unlock

--- a/run.sh
+++ b/run.sh
@@ -115,6 +115,7 @@ make -C $BUILD/../
 rc=$?; if [[ $rc != 0 ]]; then quit $rc; fi
 cp $BUILD/../models/*.xml $BUILD/etc/apteryx/schema/
 cp $BUILD/../models/*.map $BUILD/etc/apteryx/schema/
+cp $BUILD/../models/netconf-logging-options $BUILD/etc/apteryx/schema/
 
 # Check tests
 echo Checking pytest coding style ...
@@ -145,7 +146,7 @@ rm -f $BUILD/apteryx-netconf.sock
 # TEST_WRAPPER="valgrind --leak-check=full"
 # TEST_WRAPPER="valgrind --tool=cachegrind"
 G_SLICE=always-malloc LD_LIBRARY_PATH=$BUILD/usr/lib \
-        $TEST_WRAPPER ../apteryx-netconf $PARAM -m $BUILD/etc/apteryx/schema/ --unix $BUILD/apteryx-netconf.sock
+        $TEST_WRAPPER ../apteryx-netconf $PARAM -m $BUILD/etc/apteryx/schema/ -l netconf-logging-options --unix $BUILD/apteryx-netconf.sock
 rc=$?; if [[ $rc != 0 ]]; then quit $rc; fi
 sleep 0.5
 cd $BUILD/../


### PR DESCRIPTION
A new startup parameter "-l" was added to netconf. The new parameter specifies the name of a file that contains the logging options to be enabled. The choices are:-
edit-config
get
get-config
kill-session
lock
unlock

The options are added in a single line separated by spaces e.g if logging is only required when someone changes the config or kills a session the logging option file would contain the line:-

edit-config kill-session.

The contents of the logging file can be modified at any time and Netconf will dynamically use the new logging options.