### PR TITLE
Add support for filtering on multiple subtrees with get and get-config

### DIFF
--- a/tests/test_get_subtree.py
+++ b/tests/test_get_subtree.py
@@ -600,3 +600,32 @@ def test_get_subtree_missing():
     assert xml.tag == '{urn:ietf:params:xml:ns:netconf:base:1.0}data'
     assert len(xml.getchildren()) == 0
     print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
+
+
+def test_get_multi_subtree_select_multi():
+    select = """
+<filter type="subtree">
+<interfaces xmlns="http://example.com/ns/interfaces">
+  <interface>
+    <name>eth2</name>
+  </interface>
+</interfaces>
+<test xmlns="http://test.com/ns/yang/testing">
+  <animals>
+    <animal>
+      <name>cat</name>
+    </animal>
+    <animal>
+      <name>dog</name>
+    </animal>
+  </animals>
+</test>
+</filter>
+    """
+    m = connect()
+    xml = m.get(select).data
+    print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
+    assert xml.find('./{*}test/{*}animals/{*}animal/{*}name').text == 'cat'
+    assert xml.find('./{*}test/{*}animals/{*}animal[{*}name="cat"]/{*}type').text == 'big'
+    assert xml.find('./{*}interfaces/{*}interface[{*}name="eth2"]/{*}mtu').text == '9000'
+    m.close_session()

--- a/tests/test_with_defaults.py
+++ b/tests/test_with_defaults.py
@@ -1,4 +1,5 @@
-from conftest import _get_test_with_defaults_and_filter
+from lxml import etree
+from conftest import connect, _get_test_with_defaults_and_filter
 
 
 def test_with_defaults_explicit():
@@ -181,3 +182,17 @@ def test_with_defaults_trim_subtree():
 </nc:data>
     """
     _get_test_with_defaults_and_filter(select, with_defaults, expected)
+
+
+def test_with_defaults_trim_subtree_all():
+    m = connect()
+    xml = m.get(with_defaults='trim').data
+    print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
+    # Full tree should be returned
+    assert xml.find('./{*}test/{*}settings/{*}debug').text == 'enable'
+    assert xml.find('./{*}test/{*}state/{*}counter').text == '42'
+    assert xml.find('./{*}test/{*}animals/{*}animal/{*}name').text == 'cat'
+    assert xml.find('./{*}interfaces/{*}interface/{*}name').text == 'eth0'
+    # interfaces/interface/eth1/mtu should not be present as it is a default
+    assert xml.find('./{*}interfaces/{*}interface[{*}name="eth1"]/{*}mtu') is None
+    m.close_session()


### PR DESCRIPTION
The get handling code has been refactored to allow for a get or get-config request with a filter containing multiple subtrees.