### PR TITLE
Modify the handling of the xpath flag SCH_F_XPATH

### DIFF
--- a/netconf.c
+++ b/netconf.c
@@ -693,7 +693,8 @@ get_process_action (struct netconf_session *session, xmlNode *node, int schflags
             {
                 char *path = g_strstrip (split[i]);
                 qschema = NULL;
-                query = sch_path_to_gnode (g_schema, NULL, path, schflags | SCH_F_XPATH, &qschema);
+                schflags |= SCH_F_XPATH;
+                query = sch_path_to_gnode (g_schema, NULL, path, schflags, &qschema);
                 if (!query)
                 {
                     VERBOSE ("XPATH: malformed filter\n");

--- a/tests/test_get_xpath.py
+++ b/tests/test_get_xpath.py
@@ -251,3 +251,133 @@ def test_get_multi_xpath_select_multi():
 </nc:data>
     """
     _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_simple_star():
+    xpath = ("/test/animals/animal/*/name")
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test xmlns="http://test.com/ns/yang/testing">
+    <animals>
+      <animal>
+        <name>cat</name>
+      </animal>
+      <animal>
+        <name>dog</name>
+      </animal>
+      <animal>
+        <name>hamster</name>
+      </animal>
+      <animal>
+        <name>mouse</name>
+      </animal>
+      <animal>
+        <name>parrot</name>
+      </animal>
+    </animals>
+  </test>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_multi_layers_star():
+    xpath = ("/test/animals/*/name")
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test xmlns="http://test.com/ns/yang/testing">
+    <animals>
+      <animal>
+        <name>cat</name>
+      </animal>
+      <animal>
+        <name>dog</name>
+      </animal>
+      <animal>
+        <name>hamster</name>
+      </animal>
+      <animal>
+        <name>mouse</name>
+      </animal>
+      <animal>
+        <name>parrot</name>
+      </animal>
+    </animals>
+  </test>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_multi_layers_star_field():
+    xpath = ("/test/animals/*/colour")
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test xmlns="http://test.com/ns/yang/testing">
+    <animals>
+      <animal>
+        <name>dog</name>
+        <colour>brown</colour>
+      </animal>
+      <animal>
+        <name>mouse</name>
+        <colour>grey</colour>
+      </animal>
+      <animal>
+        <name>parrot</name>
+        <colour>blue</colour>
+      </animal>
+    </animals>
+  </test>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_slash_slash_field():
+    xpath = ("/test/animals//colour")
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test xmlns="http://test.com/ns/yang/testing">
+    <animals>
+      <animal>
+        <name>dog</name>
+        <colour>brown</colour>
+      </animal>
+      <animal>
+        <name>mouse</name>
+        <colour>grey</colour>
+      </animal>
+      <animal>
+        <name>parrot</name>
+        <colour>blue</colour>
+      </animal>
+    </animals>
+  </test>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_multiple_slash_slash_field():
+    xpath = ("/test/animals//food//type")
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test xmlns="http://test.com/ns/yang/testing">
+    <animals>
+      <animal>
+        <name>hamster</name>
+        <food>
+          <name>banana</name>
+          <type>fruit</type>
+        </food>
+        <food>
+          <name>nuts</name>
+          <type>kibble</type>
+        </food>
+      </animal>
+    </animals>
+  </test>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')


### PR DESCRIPTION
The flag SCH_F_XPATH is now set in schflags as it is used in two stages of processing a get xpath request.

Tests for the improved xpath handling of /*/ and // have been added.