### PR TITLE
Add support for reporting YANG model features in the capabilities

### DIFF
--- a/models/netconf-features.info
+++ b/models/netconf-features.info
@@ -1,0 +1,1 @@
+example ether,fast

--- a/models/rfc6243_example.xml
+++ b/models/rfc6243_example.xml
@@ -1,16 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<MODULE xmlns="http://example.com/ns/interfaces" xmlns:exam="http://example.com/ns/interfaces" model="example" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/alliedtelesis/apteryx-xml https://github.com/alliedtelesis/apteryx-xml/releases/download/v1.2/apteryx.xsd">
+<MODULE xmlns="http://example.com/ns/interfaces" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/alliedtelesis/apteryx-xml https://github.com/alliedtelesis/apteryx-xml/releases/download/v1.2/apteryx.xsd" model="example" namespace="http://example.com/ns/interfaces" prefix="exam" organization="Dummy Organization" version="2023-04-04">
   <NODE name="interfaces" help="Example interfaces group">
     <NODE name="interface" help="Example interface entry">
       <NODE name="*" help="The interface entry with key name">
         <NODE name="name" mode="rw" help="The administrative name of the interface. This is an identifier that is only unique within the scope of this list, and only within a specific server."/>
-        <NODE name="mtu" mode="rw" default="1500" help="The maximum transmission unit (MTU) value assigned to this interface."/>
+        <NODE name="mtu" mode="rw" default="1500" help="The maximum transmission unit (MTU) value assigned to this interface." range="0..4294967295"/>
         <NODE name="status" mode="r" default="up" help="The current status of this interface.">
           <VALUE name="up" value="up"/>
           <VALUE name="waking up" value="waking up"/>
           <VALUE name="not feeling so good" value="not feeling so good"/>
           <VALUE name="better check it out" value="better check it out"/>
-           <VALUE name="better call for help" value="better call for help"/>
+          <VALUE name="better call for help" value="better call for help"/>
         </NODE>
       </NODE>
     </NODE>

--- a/models/rfc6243_example.yang
+++ b/models/rfc6243_example.yang
@@ -4,6 +4,24 @@ module example {
 
      prefix exam;
 
+     organization
+        "Dummy Organization";
+
+     revision 2023-04-04 {
+        description
+           "Initial revision";
+     }
+
+     feature ether {
+        description
+          "Interface has attribute ether";
+     }
+
+     feature fast {
+        description
+          "Interface has attribute fast";
+     }
+
      typedef status-type {
         description "Interface status";
         type enumeration {

--- a/netconf.c
+++ b/netconf.c
@@ -336,8 +336,16 @@ schema_set_model_information (xmlNode * cap)
             strlen (loaded->model))
         {
             xml_child = xmlNewChild (cap, NULL, BAD_CAST "capability", NULL);
-            capability = g_strdup_printf ("%s?module=%s&amp;revision=%s",
-                                          loaded->ns_href, loaded->model, loaded->version);
+            if (loaded->features)
+            {
+                capability = g_strdup_printf ("%s?module=%s&amp;revision=%s&amp;features=%s",
+                                              loaded->ns_href, loaded->model, loaded->version, loaded->features);
+            }
+            else
+            {
+                capability = g_strdup_printf ("%s?module=%s&amp;revision=%s",
+                                              loaded->ns_href, loaded->model, loaded->version);
+            }
             xmlNodeSetContent (xml_child, BAD_CAST capability);
             g_free (capability);
         }

--- a/run.sh
+++ b/run.sh
@@ -115,6 +115,7 @@ make -C $BUILD/../
 rc=$?; if [[ $rc != 0 ]]; then quit $rc; fi
 cp $BUILD/../models/*.xml $BUILD/etc/apteryx/schema/
 cp $BUILD/../models/*.map $BUILD/etc/apteryx/schema/
+cp $BUILD/../models/*.info $BUILD/etc/apteryx/schema/
 cp $BUILD/../models/netconf-logging-options $BUILD/etc/apteryx/schema/
 
 # Check tests

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,0 +1,37 @@
+import socket
+import os
+import select
+
+
+def test_connect_hello():
+    cwd = os.getcwd()
+    unix_path = cwd + '/.build/apteryx-netconf.sock'
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(unix_path)
+    sock.setblocking(0)
+    ready = select.select([sock], [], [], 2)
+    if ready[0]:
+        data = sock.recv(4096)
+        sock.close()
+        result = data.decode('utf-8')
+        assert (result.find('<nc:hello xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">') > 0)
+    else:
+        sock.close()
+        assert (False)
+
+
+def test_connect_hello_feature():
+    cwd = os.getcwd()
+    unix_path = cwd + '/.build/apteryx-netconf.sock'
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(unix_path)
+    sock.setblocking(0)
+    ready = select.select([sock], [], [], 2)
+    if ready[0]:
+        data = sock.recv(4096)
+        sock.close()
+        result = data.decode('utf-8')
+        assert (result.find('module=example&amp;revision=2023-04-04&amp;features=ether,fast') > 0)
+    else:
+        sock.close()
+        assert (False)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -2,9 +2,6 @@ from conftest import connect
 from random import randint
 import re
 import time
-import socket
-import os
-import select
 
 OK_REGEX_PATTERN = "<nc:ok/>"
 
@@ -227,20 +224,3 @@ def test_multi_kill():
     response = None
     response = m1.close_session()
     assert (response.ok is True)
-
-
-def test_connect_hello():
-    cwd = os.getcwd()
-    unix_path = cwd + '/.build/apteryx-netconf.sock'
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.connect(unix_path)
-    sock.setblocking(0)
-    ready = select.select([sock], [], [], 2)
-    if ready[0]:
-        data = sock.recv(4096)
-        sock.close()
-        result = data.decode('utf-8')
-        assert (result.find('<nc:hello xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">') > 0)
-    else:
-        sock.close()
-        assert (False)


### PR DESCRIPTION
This change allows a user to specify any supported features in a YANG model. Netconf parses any files of the type .info looking for lines which specify a YANG model name and a comma separated list of features.