### PR TITLE
Implement maximum number of sessions limit

### DIFF
--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -224,3 +224,32 @@ def test_multi_kill():
     response = None
     response = m1.close_session()
     assert (response.ok is True)
+
+
+def test_max_session():
+    """
+    max-sessions defaults to 4. verify that we can make 4 connections, but
+    not 5.
+    """
+    try:
+        m1 = connect()
+        assert (m1.connected is True)
+
+        m2 = connect()
+        assert (m2.connected is True)
+
+        m3 = connect()
+        assert (m3.connected is True)
+
+        m4 = connect()
+        assert (m4.connected is True)
+
+        m5 = connect()
+        assert (m5.connected is False)
+    except Exception:
+        pass
+    finally:
+        m1.close_session()
+        m2.close_session()
+        m3.close_session()
+        m4.close_session()


### PR DESCRIPTION
Start counting active sessions and implement a maximum number of sessions, settable to between 1 and 10 inclusive, defaulting to 4.

Add a test to verify that the default limit of 4 does indeed limit the number of sessions to 4, with the 5th session being forcibly closed.