### PR TITLE
Check for message-id in all RPCs

### DIFF
--- a/netconf.c
+++ b/netconf.c
@@ -1918,6 +1918,17 @@ netconf_handle_session (int fd)
             break;
         }
 
+        /* Check whether the <rpc> element has the mandatory attribute - "message-id "*/
+        if (!xmlHasProp (rpc, BAD_CAST "message-id"))
+        {
+            send_rpc_error_full (session, rpc, NC_ERR_TAG_MISSING_ATTR, NC_ERR_TYPE_PROTOCOL,
+                                 "RPC missing message-id attribute",
+                                 "rpc", "message-id", false);
+            xmlFreeDoc (doc);
+            g_free (message);
+            break;
+        }
+
         if (g_strcmp0 ((char *) child->name, "close-session") == 0)
         {
             VERBOSE ("Closing session\n");

--- a/tests/test_edit_config.py
+++ b/tests/test_edit_config.py
@@ -71,8 +71,8 @@ def test_edit_config_bad_target():
   </test>
 </config>
 """
-    xml = _edit_config_test(payload, post_xpath='/test/settings/priority', targ="candidate",
-                            expect_err={"tag": "operation-not-supported", "type": "protocol"})
+    _edit_config_test(payload, post_xpath='/test/settings/priority', targ="candidate",
+                      expect_err={"tag": "operation-not-supported", "type": "protocol"})
 
 
 def test_edit_config_multi():


### PR DESCRIPTION
Message-id is a mandatory parameter in all RPCs. This wasn't been checked.

Also fixed a minor issue in tests.
