### PR TITLE
Add counters

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -65,6 +65,27 @@ typedef enum
     LOG_UNLOCK                  = (1 << 5),  /* Log unlock requests */
 } logging_flags;
 
+/* Define session counters from the RFC 6022 /netconf-state/sessions group
+ * An instance of these is also used for global counters
+ */
+typedef struct
+{
+    uint32_t in_rpcs;
+    uint32_t in_bad_rpcs;
+    uint32_t out_rpc_errors;
+    uint32_t out_notifications;
+} session_counters_t;
+
+/* Define global counters from the RFC 6022 /netconf-state/statistics group */
+typedef struct
+{
+    gchar *netconf_start_time;
+    uint32_t in_bad_hellos;
+    uint32_t in_sessions;
+    uint32_t dropped_sessions;
+    session_counters_t session_totals;
+} global_statistics_t;
+
 /* Main loop */
 extern GMainLoop *g_loop;
 

--- a/main.c
+++ b/main.c
@@ -37,6 +37,8 @@ GMainLoop *g_loop = NULL;
 static int accept_fd = -1;
 static GThreadPool *workers = NULL;
 
+extern global_statistics_t netconf_global_stats;
+
 static gboolean
 termination_handler (gpointer arg1)
 {
@@ -111,6 +113,7 @@ main (int argc, char *argv[])
 {
     GError *error = NULL;
     GOptionContext *context;
+    GDateTime *now = NULL;
 
     /* Parse options */
     context = g_option_context_new ("- Netconf access to Apteryx");
@@ -138,6 +141,11 @@ main (int argc, char *argv[])
 
     /* Listen Socket */
     g_thread = g_thread_new ("netconf-accept", netconf_accept_thread, (gpointer) unix_path);
+
+    /* Record start time */
+    now = g_date_time_new_now_utc ();
+    netconf_global_stats.netconf_start_time = g_date_time_format (now, "%Y-%m-%dT%H:%M:%SZ%:z");
+    g_date_time_unref (now);
 
     /* Main Loop */
     g_loop = g_main_loop_new (NULL, FALSE);

--- a/tests/test_edit_config.py
+++ b/tests/test_edit_config.py
@@ -71,8 +71,22 @@ def test_edit_config_bad_target():
   </test>
 </config>
 """
-    _edit_config_test(payload, post_xpath='/test/settings/priority', targ="candidate",
+    _edit_config_test(payload, targ="candidate",
                       expect_err={"tag": "operation-not-supported", "type": "protocol"})
+
+
+def test_edit_config_bad_operation():
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test>
+    <settings>
+        <priority xc:operation="bob">5</priority>
+    </settings>
+  </test>
+</config>
+"""
+    _edit_config_test(payload, expect_err={"tag": "unknown-attribute", "type": "protocol"})
 
 
 def test_edit_config_multi():


### PR DESCRIPTION
Taking the lead from the IETF Netconf monitoring data model, (RFC 6022) add session and global counters and other statistics.