### PR TITLE
Fix tests for data with leaf-lists

### DIFF
--- a/tests/test_get_subtree.py
+++ b/tests/test_get_subtree.py
@@ -242,6 +242,10 @@ def test_get_subtree_list_container():
         <name>parrot</name>
         <type>big</type>
         <colour>blue</colour>
+        <toys>
+          <toy>puzzles</toy>
+          <toy>rings</toy>
+        </toys>
       </animal>
     </animals>
   </test>
@@ -285,6 +289,10 @@ def test_get_subtree_list_element():
         <name>parrot</name>
         <type>big</type>
         <colour>blue</colour>
+        <toys>
+          <toy>puzzles</toy>
+          <toy>rings</toy>
+        </toys>
       </animal>
     </animals>
   </test>

--- a/tests/test_get_xpath.py
+++ b/tests/test_get_xpath.py
@@ -163,6 +163,10 @@ def test_get_xpath_list_trunk():
         <name>parrot</name>
         <type>big</type>
         <colour>blue</colour>
+        <toys>
+          <toy>puzzles</toy>
+          <toy>rings</toy>
+        </toys>
       </animal>
     </animals>
   </test>


### PR DESCRIPTION
A number of tests have been passing when they should not have. This change updates those tests to reflect that leaf-list information should be returned.