### PR TITLE
Fix response to GET RPC calls that include the "with-defaults" option

### DIFF
--- a/netconf.c
+++ b/netconf.c
@@ -877,7 +877,6 @@ get_query_to_xml (struct netconf_session *session, GNode *query, sch_node *rsche
     {
         if (tree)
         {
-            rnode = get_response_node (tree, rdepth);
             sch_traverse_tree (g_schema, rschema, rnode, schflags);
         }
         else if (!tree)


### PR DESCRIPTION
Currently, GET RPC requests including "with-defaults" element set to "report-all" returns additional nodes that exist in the level above the requested node. The patch attempts to fix this with the intention of returning specified node level information only.