### PR TITLE
Fix with defaults - report-all failing some tests

### DIFF
--- a/tests/test_with_defaults.py
+++ b/tests/test_with_defaults.py
@@ -65,6 +65,70 @@ def test_with_defaults_report_all():
     _get_test_with_defaults_and_filter(xpath, with_defaults, expected, f_type='xpath')
 
 
+def test_with_defaults_report_all_level_1():
+    with_defaults = 'report-all'
+    xpath = '/interfaces/interface'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces xmlns="http://example.com/ns/interfaces">
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth1</name>
+            <mtu>1500</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <mtu>1500</mtu>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(xpath, with_defaults, expected, f_type='xpath')
+
+
+def test_with_defaults_report_all_level_2():
+    with_defaults = 'report-all'
+    xpath = '/interfaces/interface/*'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces xmlns="http://example.com/ns/interfaces">
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth1</name>
+            <mtu>1500</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <mtu>1500</mtu>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(xpath, with_defaults, expected, f_type='xpath')
+
+
 def test_with_defaults_trim():
     with_defaults = 'trim'
     xpath = '/interfaces'
@@ -196,3 +260,36 @@ def test_with_defaults_trim_subtree_all():
     # interfaces/interface/eth1/mtu should not be present as it is a default
     assert xml.find('./{*}interfaces/{*}interface[{*}name="eth1"]/{*}mtu') is None
     m.close_session()
+
+
+def test_with_defaults_get_subtree_select_one_node_other():
+    with_defaults = 'report-all'
+    select = '<test><animals><animal><name>cat</name><food/></animal></animals></test>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+            <animal>
+                <name>cat</name>
+            </animal>
+        </animals>
+    </test>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)
+
+
+def test_with_default_report_all_get_leaf():
+    with_defaults = 'report-all'
+    select = '<interfaces><interface><name>eth0</name><status/></interface></interfaces>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces xmlns="http://example.com/ns/interfaces">
+        <interface>
+            <name>eth0</name>
+            <status>up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)


### PR DESCRIPTION
The with default handling for netconf was mostly copied from the equivalent apteryx-rest rest.c code. There are differences however between the way restconf and netconf return data. Restconf only returns information from the query end, but netconf returns a complete tree from the top of the model. This means the way the with-defaults is added needed to change.

The patch was authored by gcampbell512.