### PR TITLE
Fix with defaults - report-all failing some tests

### DIFF
--- a/netconf.c
+++ b/netconf.c
@@ -852,20 +852,8 @@ get_full_tree ()
     return tree;
 }
 
-static GNode*
-get_response_node (GNode *tree, int rdepth)
-{
-    GNode *rnode = tree;
-
-    while (--rdepth && rnode)
-        rnode = rnode->children;
-
-    return rnode;
-}
-
 static void
-get_query_to_xml (struct netconf_session *session, GNode *query, sch_node *rschema, GNode *rnode,
-                  int rdepth, GNode *qnode, int schflags, GList **xml_list)
+get_query_to_xml (struct netconf_session *session, GNode *query, int rdepth, int schflags, GList **xml_list)
 {
     GNode *tree;
     xmlNode *xml = NULL;
@@ -881,28 +869,22 @@ get_query_to_xml (struct netconf_session *session, GNode *query, sch_node *rsche
     }
 
     tree = query ? apteryx_query (query) : get_full_tree ();
-    if (rschema && (schflags & SCH_F_ADD_DEFAULTS))
+    if (schflags & SCH_F_ADD_DEFAULTS)
     {
         if (tree)
-        {
-            rnode = get_response_node (tree, rdepth);
-            sch_traverse_tree (g_schema, rschema, rnode, schflags, 0);
-        }
-        else if (!tree)
+            sch_traverse_tree (g_schema, NULL, tree, schflags | SCH_F_FILTER_RDEPTH, rdepth);
+        else
         {
             /* Nothing in the database, but we may have defaults! */
             tree = query;
             query = NULL;
-            sch_traverse_tree (g_schema, rschema, qnode, schflags, 0);
+            sch_traverse_tree (g_schema, NULL, tree, schflags | SCH_F_FILTER_RDEPTH, rdepth);
         }
     }
 
     if (tree && (schflags & SCH_F_TRIM_DEFAULTS))
-    {
-        /* Get rid of any unwanted nodes */
-        GNode *rnode = get_response_node (tree, rdepth);
-        sch_traverse_tree (g_schema, rschema, rnode, schflags, 0);
-     }
+            sch_traverse_tree (g_schema, NULL, tree, schflags | SCH_F_FILTER_RDEPTH, rdepth);
+
     apteryx_free_tree (query);
 
     /* Convert result to XML */
@@ -915,45 +897,26 @@ static void
 get_query_schema (struct netconf_session *session, GNode *query, sch_node *qschema,
                   int schflags, bool is_filter, GList **xml_list)
 {
-    GNode *rnode = NULL;
-    sch_node *rschema = NULL;
     GNode *qnode = NULL;
     int qdepth = 0;
-    int rdepth;
-    int diff;
 
     /* Get the depth of the response which is the depth of the query
         OR the up until the first path wildcard */
     qdepth = g_node_max_height (query);
-    rdepth = 1;
-    rnode = query;
-    while (rnode &&
-            g_node_n_children (rnode) == 1 &&
-            g_strcmp0 (APTERYX_NAME (g_node_first_child (rnode)), "*") != 0)
+    qnode = query;
+    while (qnode &&
+            g_node_n_children (qnode) == 1 &&
+            g_strcmp0 (APTERYX_NAME (g_node_first_child (qnode)), "*") != 0)
     {
-        rnode = g_node_first_child (rnode);
-        rdepth++;
+        qnode = g_node_first_child (qnode);
     }
 
-    qnode = rnode;
     while (qnode->children)
         qnode = qnode->children;
 
     if (qdepth && qnode && !g_node_first_child (qnode) &&
             g_strcmp0 (APTERYX_NAME (qnode), "*") == 0)
         qdepth--;
-
-    rschema = qschema;
-    diff = qdepth - rdepth;
-    while (diff--)
-        rschema = sch_node_parent (rschema);
-
-    if (sch_node_parent (rschema) && sch_is_list (sch_node_parent (rschema)))
-    {
-        /* We need to present the list rather than the key */
-        rschema = sch_node_parent (rschema);
-        rdepth--;
-    }
 
     /* Without a query we may need to add a wildcard to get everything from here down */
     if (is_filter && qdepth == g_node_max_height (query) && !(schflags & SCH_F_DEPTH_ONE))
@@ -969,7 +932,7 @@ get_query_schema (struct netconf_session *session, GNode *query, sch_node *qsche
         }
     }
 
-    get_query_to_xml (session, query, rschema, rnode, rdepth, qnode, schflags, xml_list);
+    get_query_to_xml (session, query, qdepth, schflags, xml_list);
 }
 
 static int
@@ -1202,7 +1165,7 @@ handle_get (struct netconf_session *session, xmlNode * rpc, gboolean config_only
 
     /* Catch for get without filter */
     if (!xml_list)
-        get_query_to_xml (session, NULL, NULL, NULL, 0, NULL, schflags, &xml_list);
+        get_query_to_xml (session, NULL, 0, schflags, &xml_list);
 
     /* Send response */
     send_rpc_data (session, rpc, xml_list);

--- a/tests/test_with_defaults.py
+++ b/tests/test_with_defaults.py
@@ -65,6 +65,70 @@ def test_with_defaults_report_all():
     _get_test_with_defaults_and_filter(xpath, with_defaults, expected, f_type='xpath')
 
 
+def test_with_defaults_report_all_level_1():
+    with_defaults = 'report-all'
+    xpath = '/interfaces/interface'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces xmlns="http://example.com/ns/interfaces">
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth1</name>
+            <mtu>1500</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <mtu>1500</mtu>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(xpath, with_defaults, expected, f_type='xpath')
+
+
+def test_with_defaults_report_all_level_2():
+    with_defaults = 'report-all'
+    xpath = '/interfaces/interface/*'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces xmlns="http://example.com/ns/interfaces">
+        <interface>
+            <name>eth0</name>
+            <mtu>8192</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth1</name>
+            <mtu>1500</mtu>
+            <status>up</status>
+        </interface>
+        <interface>
+            <name>eth2</name>
+            <mtu>9000</mtu>
+            <status>not feeling so good</status>
+        </interface>
+        <interface>
+            <name>eth3</name>
+            <mtu>1500</mtu>
+            <status>waking up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(xpath, with_defaults, expected, f_type='xpath')
+
+
 def test_with_defaults_trim():
     with_defaults = 'trim'
     xpath = '/interfaces'
@@ -196,3 +260,86 @@ def test_with_defaults_trim_subtree_all():
     # interfaces/interface/eth1/mtu should not be present as it is a default
     assert xml.find('./{*}interfaces/{*}interface[{*}name="eth1"]/{*}mtu') is None
     m.close_session()
+
+
+def test_with_defaults_get_subtree_select_one_node_other():
+    with_defaults = 'report-all'
+    select = '<test><animals><animal><name>cat</name><food/></animal></animals></test>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+            <animal>
+                <name>cat</name>
+            </animal>
+        </animals>
+    </test>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)
+
+
+def test_with_default_report_all_get_leaf():
+    with_defaults = 'report-all'
+    select = '<interfaces><interface><name>eth0</name><status/></interface></interfaces>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <interfaces xmlns="http://example.com/ns/interfaces">
+        <interface>
+            <name>eth0</name>
+            <status>up</status>
+        </interface>
+    </interfaces>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)
+
+
+def test_with_default_report_all_get_leaf_different_depths():
+    with_defaults = 'report-all'
+    select = '''
+              <test>
+                <settings>
+                  <enable/>
+                </settings>
+                <state>
+                    <uptime>
+                        <seconds/>
+                    </uptime>
+                </state>
+                <animals>
+                    <animal>
+                        <name>hamster</name>
+                        <food>
+                            <name>banana</name>
+                            <type/>
+                        </food>
+                    </animal>
+                </animals>
+            </test>
+            '''
+
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test xmlns="http://test.com/ns/yang/testing">
+    <settings>
+      <enable>true</enable>
+    </settings>
+    <state>
+      <uptime>
+        <seconds>20</seconds>
+      </uptime>
+    </state>
+    <animals>
+      <animal>
+        <name>hamster</name>
+        <food>
+          <name>banana</name>
+          <type>fruit</type>
+        </food>
+      </animal>
+    </animals>
+  </test>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)


### PR DESCRIPTION
The with default handling for netconf was mostly copied from the equivalent apteryx-rest rest.c code. There are differences however between the way restconf and netconf return data. Restconf only returns information from the query end, but netconf returns a complete tree from the top of the model. This means the way the with-defaults is added needed to change.

The patch has been adapted based on the original commit authored by gcampbell512.