### PR TITLE
Support a netconf query with a value/content, RFC-6241 section 6.2.6

### DIFF
--- a/tests/test_get_subtree.py
+++ b/tests/test_get_subtree.py
@@ -548,23 +548,12 @@ def test_get_subtree_select_key_other_field_value():
     <test xmlns="http://test.com/ns/yang/testing">
         <animals>
             <animal>
-                <name>cat</name>
-                <type>big</type>
-            </animal>
-            <animal>
-                <name>dog</name>
-            </animal>
-            <animal>
                 <name>hamster</name>
                 <type>little</type>
             </animal>
             <animal>
                 <name>mouse</name>
                 <type>little</type>
-            </animal>
-            <animal>
-                <name>parrot</name>
-                <type>big</type>
             </animal>
         </animals>
     </test>
@@ -637,3 +626,91 @@ def test_get_multi_subtree_select_multi():
     assert xml.find('./{*}test/{*}animals/{*}animal[{*}name="cat"]/{*}type').text == 'big'
     assert xml.find('./{*}interfaces/{*}interface[{*}name="eth2"]/{*}mtu').text == '9000'
     m.close_session()
+
+
+def test_get_subtree_select_key_value_other_field_exp_simple():
+    select = """
+<test>
+    <animals>
+        <animal>
+            <name/>
+                <colour>brown</colour>
+        </animal>
+    </animals>
+</test>
+    """
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+            <animal>
+                <name>dog</name>
+                <colour>brown</colour>
+            </animal>
+        </animals>
+    </test>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_select_key_value_other_field_exp_deep():
+    select = """
+<test>
+    <animals>
+        <animal>
+            <name>hamster</name>
+                <food>
+                    <name/>
+                        <type>kibble</type>
+                </food>
+        </animal>
+    </animals>
+</test>
+    """
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+            <animal>
+                <name>hamster</name>
+                <food>
+                    <name>nuts</name>
+                    <type>kibble</type>
+                </food>
+            </animal>
+        </animals>
+    </test>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_select_key_value_other_field_exp_two_results():
+    select = """
+<test>
+    <animals>
+        <animal>
+            <name/>
+                <type>1</type>
+        </animal>
+    </animals>
+</test>
+    """
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+            <animal>
+                <name>cat</name>
+                <type>big</type>
+            </animal>
+            <animal>
+                <name>parrot</name>
+                <type>big</type>
+            </animal>
+        </animals>
+    </test>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)

--- a/tests/test_with_defaults.py
+++ b/tests/test_with_defaults.py
@@ -220,6 +220,16 @@ def test_with_defaults_report_all_subtree():
     _get_test_with_defaults_and_filter(select, with_defaults, expected)
 
 
+# Test case where a query fails returns no result and the query itself is used to fill in defaults
+def test_with_defaults_report_all_subtree_no_match():
+    with_defaults = 'report-all'
+    select = '<interfaces><interface><name>eth4</name></interface></interfaces>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"/>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)
+
+
 def test_with_defaults_trim_subtree():
     with_defaults = 'trim'
     select = '<interfaces></interfaces>'


### PR DESCRIPTION
If the GET type is subtree and a value is specified as part of the get request, then call the new function apteryx_query_full to get the tree.