### PR TITLE
Support translated YANG models.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -67,6 +67,7 @@ fi
 rm -f $BUILD/etc/apteryx/schema/*
 cp $BUILD/apteryx-xml/models/*.xml $BUILD/etc/apteryx/schema/
 cp $BUILD/apteryx-xml/models/*.map $BUILD/etc/apteryx/schema/
+cp $BUILD/apteryx-xml/models/*.xlat $BUILD/etc/apteryx/schema/
 
 # Check openssh
 if [ ! -d openssh ]; then

--- a/tests/test_get_subtree.py
+++ b/tests/test_get_subtree.py
@@ -714,3 +714,204 @@ def test_get_subtree_select_key_value_other_field_exp_two_results():
 </nc:data>
     """
     _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_list_container_translate():
+    select = '<xlat-test><xlat-animals/></xlat-test>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <xlat-test xmlns="http://test.com/ns/yang/xlat-testing">
+    <xlat-animals>
+      <xlat-animal>
+        <name>cat</name>
+        <type>fast</type>
+      </xlat-animal>
+      <xlat-animal>
+        <name>dog</name>
+        <colour>brown</colour>
+      </xlat-animal>
+      <xlat-animal>
+        <name>hamster</name>
+        <type>slow</type>
+        <food>
+          <name>banana</name>
+          <type>fruit</type>
+        </food>
+        <food>
+          <name>nuts</name>
+          <type>kibble</type>
+        </food>
+      </xlat-animal>
+      <xlat-animal>
+        <name>mouse</name>
+        <type>slow</type>
+        <colour>grey</colour>
+      </xlat-animal>
+      <xlat-animal>
+        <name>parrot</name>
+        <type>fast</type>
+        <colour>blue</colour>
+        <toys>
+          <toy>puzzles</toy>
+          <toy>rings</toy>
+        </toys>
+      </xlat-animal>
+    </xlat-animals>
+  </xlat-test>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_list_element_translate():
+    select = '<xlat-test><xlat-animals><xlat-animal/></xlat-animals></xlat-test>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <xlat-test xmlns="http://test.com/ns/yang/xlat-testing">
+    <xlat-animals>
+      <xlat-animal>
+        <name>cat</name>
+        <type>fast</type>
+      </xlat-animal>
+      <xlat-animal>
+        <name>dog</name>
+        <colour>brown</colour>
+      </xlat-animal>
+      <xlat-animal>
+        <name>hamster</name>
+        <type>slow</type>
+        <food>
+          <name>banana</name>
+          <type>fruit</type>
+        </food>
+        <food>
+          <name>nuts</name>
+          <type>kibble</type>
+        </food>
+      </xlat-animal>
+      <xlat-animal>
+        <name>mouse</name>
+        <type>slow</type>
+        <colour>grey</colour>
+      </xlat-animal>
+      <xlat-animal>
+        <name>parrot</name>
+        <type>fast</type>
+        <colour>blue</colour>
+        <toys>
+          <toy>puzzles</toy>
+          <toy>rings</toy>
+        </toys>
+      </xlat-animal>
+    </xlat-animals>
+  </xlat-test>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_list_parameter_translated():
+    select = '<xlat-test><xlat-animals><xlat-animal><name/></xlat-animal></xlat-animals></xlat-test>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <xlat-test xmlns="http://test.com/ns/yang/xlat-testing">
+    <xlat-animals>
+      <xlat-animal>
+        <name>cat</name>
+      </xlat-animal>
+      <xlat-animal>
+        <name>dog</name>
+      </xlat-animal>
+      <xlat-animal>
+        <name>hamster</name>
+      </xlat-animal>
+      <xlat-animal>
+        <name>mouse</name>
+      </xlat-animal>
+      <xlat-animal>
+        <name>parrot</name>
+      </xlat-animal>
+    </xlat-animals>
+  </xlat-test>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_list_parameter_named_translated():
+    select = '<xlat-test><xlat-animals><xlat-animal><name>cat</name><type/></xlat-animal></xlat-animals></xlat-test>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <xlat-test xmlns="http://test.com/ns/yang/xlat-testing">
+    <xlat-animals>
+      <xlat-animal>
+        <name>cat</name>
+        <type>fast</type>
+      </xlat-animal>
+    </xlat-animals>
+  </xlat-test>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_list_parameter_named_duplicate_translated():
+    select = '<xlat-test><xlat-animals><xlat-animal><name>hamster</name><food/></xlat-animal></xlat-animals></xlat-test>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <xlat-test xmlns="http://test.com/ns/yang/xlat-testing">
+    <xlat-animals>
+      <xlat-animal>
+        <name>hamster</name>
+        <food>
+          <name>banana</name>
+          <type>fruit</type>
+        </food>
+        <food>
+          <name>nuts</name>
+          <type>kibble</type>
+        </food>
+      </xlat-animal>
+    </xlat-animals>
+  </xlat-test>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_list_parameter_named_duplicate_again_translated():
+    select = '<xlat-test><xlat-animals><xlat-animal><name>hamster</name><food><name>banana</name><type/></food></xlat-animal></xlat-animals></xlat-test>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <xlat-test xmlns="http://test.com/ns/yang/xlat-testing">
+    <xlat-animals>
+      <xlat-animal>
+        <name>hamster</name>
+        <food>
+          <name>banana</name>
+          <type>fruit</type>
+        </food>
+      </xlat-animal>
+    </xlat-animals>
+  </xlat-test>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_select_interface():
+    select = """
+<filter type="subtree">
+<interfaces xmlns="http://example.com/ns/interfaces">
+  <interface>
+    <name>eth2</name>
+    <status></status>
+  </interface>
+</interfaces>
+</filter>
+    """
+    m = connect()
+    xml = m.get(select).data
+    print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
+    assert xml.find('./{*}interfaces/{*}interface[{*}name="eth2"]/{*}status').text == 'not feeling so good'
+    m.close_session()

--- a/tests/test_get_xpath.py
+++ b/tests/test_get_xpath.py
@@ -5717,3 +5717,37 @@ def test_get_xpath_functions_f31():
 </nc:data>
     """
     _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_list_select_one_trunk_translate():
+    xpath = "/xlat-test/xlat-animals/xlat-animal[name='cat']"
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <xlat-test xmlns="http://test.com/ns/yang/xlat-testing">
+        <xlat-animals>
+            <xlat-animal>
+                <name>cat</name>
+                <type>fast</type>
+            </xlat-animal>
+        </xlat-animals>
+    </xlat-test>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_list_select_one_parameter_translate():
+    xpath = "/xlat-test/xlat-animals/xlat-animal[name='cat']/type"
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <xlat-test xmlns="http://test.com/ns/yang/xlat-testing">
+        <xlat-animals>
+            <xlat-animal>
+                <name>cat</name>
+                <type>fast</type>
+            </xlat-animal>
+        </xlat-animals>
+    </xlat-test>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')


### PR DESCRIPTION
This change allows one model to be translated to another model. This is useful if multiple YANG models for the same type of data exist. In this case a back-end super YANG model is created which is a combination of the contributing models, and requests to the individual models are translated into a request of the super model and responses are translated back into the individual requesting models.