### PR TITLE
Fixed an issue determining the qdepth for a query.

### DIFF
--- a/netconf.c
+++ b/netconf.c
@@ -1414,11 +1414,10 @@ get_query_schema (struct netconf_session *session, xmlNode *rpc, GNode *query, s
         qnode = g_node_first_child (qnode);
     }
 
-    while (qnode->children)
+    while (qnode->children && qnode->children->data)
         qnode = qnode->children;
 
-    if (qdepth && qnode && !g_node_first_child (qnode) &&
-            g_strcmp0 (APTERYX_NAME (qnode), "*") == 0)
+    if (qdepth && qnode && g_strcmp0 (APTERYX_NAME (qnode), "*") == 0)
         qdepth--;
 
     /* Without a query we may need to add a wildcard to get everything from here down */


### PR DESCRIPTION
A minor issue determining the last child has been fixed. It was actually ending when it reached a GNode with no data. This was then causing the following "if" to fail.

Now the report-all is working a test needed fixing. A new test has been added that gets defaults for the test model. As the initial part of the test the /test/settings branch of the apteryx tree is deleted, leaving an empty branch with defaults that should be returned.