### PR TITLE
Fix issue with xpath query

### DIFF
--- a/netconf.c
+++ b/netconf.c
@@ -1750,6 +1750,7 @@ get_process_action (struct netconf_session *session, xmlNode *rpc, xmlNode *node
                 xlat_data = NULL;
                 schflags |= SCH_F_XPATH;
                 xpath_type x_type;
+                last_good_schema = NULL;
                 if (ns_prefix)
                 {
                     g_free (ns_prefix);


### PR DESCRIPTION
A "malformed-message" error is returned if an xpath query of the type
"/oc-sys:system/processes/process/state/name"
is made, where the xpath consists of a filter to match on the
leaf-nodes ("name") associated with multiple list entries("process").
This is because no matching apteryx-xml schema is found for the XPATH query.
The proposed change fixes this issue.