### PR TITLE
Add support for XML proxy nodes in a query

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -29,6 +29,10 @@
 #include <syslog.h>
 #include <apteryx.h>
 #include <libxml/tree.h>
+#define APTERYX_XML_LIBXML2
+#include <libxml/xpath.h>
+#include <libxml/xpathInternals.h>
+#include <libxml/debugXML.h>
 
 /* Debug */
 extern gboolean apteryx_netconf_debug;
@@ -52,7 +56,7 @@ extern gboolean apteryx_netconf_verbose;
     }
 #define ERROR(fmt, args...) \
     { \
-        syslog (LOG_CRIT, fmt, ## args); \
+        syslog (LOG_ERR, fmt, ## args); \
         fprintf (stderr, fmt, ## args); \
     }
 
@@ -159,6 +163,14 @@ typedef struct _nc_error_parms_s
     .msg  = g_string_new (NULL)                                 \
 };
 
+typedef enum
+{
+    XPATH_NONE,
+    XPATH_SIMPLE,
+    XPATH_EVALUATE,
+    XPATH_ERROR,
+} xpath_type;
+
 /* Schema */
 typedef struct _sch_instance sch_instance;
 typedef void sch_node;
@@ -173,5 +185,9 @@ GList *sch_parm_removes (sch_xml_to_gnode_parms parms);
 GList *sch_parm_creates (sch_xml_to_gnode_parms parms);
 GList *sch_parm_replaces (sch_xml_to_gnode_parms parms);
 void sch_parm_free (sch_xml_to_gnode_parms parms);
+GNode *sch_xpath_to_gnode (sch_instance * instance, sch_node * schema, const char *path, int flags,
+                           sch_node ** rschema, xpath_type *x_type, char *schema_path);
+char *sch_xpath_set_ns_path (sch_instance * instance, sch_node * schema, xmlNode * xml,
+                             xmlXPathContext *xpath_ctx, char *path);
 
 #endif /* _INTERNAL_H_ */

--- a/tests/test_get_xpath.py
+++ b/tests/test_get_xpath.py
@@ -1,4 +1,4 @@
-from conftest import _get_test_with_filter
+from conftest import _get_test_with_filter, apteryx_set, apteryx_proxy, _get_test_with_filter_expect_error
 
 
 # GET XPATH
@@ -5781,9 +5781,9 @@ def test_get_xpath_relative_path_dot_dot():
 def test_get_xpath_relative_path_dot_dot_root():
     xpath = "/.."
     expected = """
-<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"/>
+XPATH: malformed filter
     """
-    _get_test_with_filter(xpath, expected, f_type='xpath')
+    _get_test_with_filter_expect_error(xpath, expected, f_type='xpath')
 
 
 def test_get_xpath_relative_path_dot_dot_field():
@@ -5885,9 +5885,9 @@ def test_get_xpath_relative_path_dot_dot_dot_dot():
 def test_get_xpath_relative_path_dot_dot_dot_dot_dot_dot():
     xpath = "/test/animals/animal/../../.."
     expected = """
-<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"/>
+XPATH: malformed filter
     """
-    _get_test_with_filter(xpath, expected, f_type='xpath')
+    _get_test_with_filter_expect_error(xpath, expected, f_type='xpath')
 
 
 def test_get_xpath_slash_slash_ns():
@@ -5971,5 +5971,151 @@ def test_get_xpath_node_wildcard_2():
   </test>
 </nc:data>
 
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_list_entry_leaf_node_1():
+    xpath = "/test/animals/animal[name='hamster']"
+    expected = """
+    <nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+      <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+          <animal>
+            <name>hamster</name>
+            <type>little</type>
+            <food>
+              <name>banana</name>
+              <type>fruit</type>
+            </food>
+            <food>
+              <name>nuts</name>
+              <type>kibble</type>
+            </food>
+          </animal>
+        </animals>
+      </test>
+    </nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_list_entry_leaf_node_2():
+    xpath = "/test/animals/animal/name"
+    expected = """
+    <nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+      <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+          <animal>
+            <name>cat</name>
+          </animal>
+          <animal>
+            <name>dog</name>
+          </animal>
+          <animal>
+            <name>hamster</name>
+          </animal>
+          <animal>
+            <name>mouse</name>
+          </animal>
+          <animal>
+            <name>parrot</name>
+          </animal>
+        </animals>
+      </test>
+    </nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_list_entry_leaf_node_3():
+    xpath = "/test/animals/animal/colour"
+    expected = """
+    <nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+      <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+          <animal>
+            <name>dog</name>
+            <colour>brown</colour>
+          </animal>
+          <animal>
+            <name>mouse</name>
+            <colour>grey</colour>
+          </animal>
+          <animal>
+            <name>parrot</name>
+            <colour>blue</colour>
+          </animal>
+        </animals>
+      </test>
+    </nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_list_entry_leaf_node_4():
+    xpath = "/test/animals/animal/toys"
+    expected = """
+    <nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+      <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+          <animal>
+            <name>parrot</name>
+            <toys>
+              <toy>puzzles</toy>
+              <toy>rings</toy>
+            </toys>
+          </animal>
+        </animals>
+      </test>
+    </nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_list_entry_leaf_node_5():
+    xpath = "/test/animals/animal/food/name"
+    expected = """
+    <nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+      <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+          <animal>
+            <name>hamster</name>
+            <food>
+              <name>banana</name>
+            </food>
+            <food>
+              <name>nuts</name>
+            </food>
+          </animal>
+        </animals>
+      </test>
+    </nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_proxy_list_select_one_trunk():
+    apteryx_set("/logical-elements/logical-element/loop/name", "loopy")
+    apteryx_set("/logical-elements/logical-element/loop/root", "root")
+    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx_proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
+    xpath = "/logical-elements/logical-element[name='loopy']/test/animals/animal[name='cat']"
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <logical-elements xmlns="http://example.com/ns/logical-elements">
+    <logical-element>
+      <name>loopy</name>
+      <test xmlns="http://test.com/ns/yang/testing">
+        <animals>
+          <animal>
+            <name>cat</name>
+            <type>big</type>
+          </animal>
+        </animals>
+      </test>
+    </logical-element>
+  </logical-elements>
+</nc:data>
     """
     _get_test_with_filter(xpath, expected, f_type='xpath')

--- a/tests/test_with_defaults.py
+++ b/tests/test_with_defaults.py
@@ -1,5 +1,5 @@
 from lxml import etree
-from conftest import connect, _get_test_with_defaults_and_filter
+from conftest import connect, _get_test_with_defaults_and_filter, apteryx_set, apteryx_proxy
 from test_edit_config import _edit_config_test
 
 
@@ -437,6 +437,30 @@ def test_with_default_report_all_on_empty_branch():
       </animal>
     </animals>
   </test>
+</nc:data>
+    """
+    _get_test_with_defaults_and_filter(select, with_defaults, expected)
+
+
+def test_with_default_report_all_proxy_get_leaf():
+    apteryx_set("/logical-elements/logical-element/loop/name", "loopy")
+    apteryx_set("/logical-elements/logical-element/loop/root", "root")
+    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx_proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
+    with_defaults = 'report-all'
+    select = '<logical-elements><logical-element><name>loopy</name><interfaces><interface><name>eth0</name><status/></interface></interfaces></logical-element></logical-elements>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <logical-elements xmlns="http://example.com/ns/logical-elements">
+    <logical-element>
+      <interfaces xmlns="http://example.com/ns/interfaces">
+        <interface>
+          <name>eth0</name>
+          <status>up</status>
+        </interface>
+      </interfaces>
+    </logical-element>
+  </logical-elements>
 </nc:data>
     """
     _get_test_with_defaults_and_filter(select, with_defaults, expected)


### PR DESCRIPTION
XML proxy nodes allow a schema to branch to using a remote apteryx database for a query. This change works with a companion change in apteryx-xml/schema.c. A copy of sch_path_to_gnode in schema.c has been imported into data.c and modified to handle the complexities of xpath parsing.