### PR TITLE
Fix memory leak issues reported by valgrind

### DIFF
--- a/data.c
+++ b/data.c
@@ -423,7 +423,6 @@ _operation_ok (_sch_xml_to_gnode_parms *_parms, xmlNode *xml, char *curr_op, cha
         }
         else
         {
-            g_free (attr);
             _parms->out_error.tag = NC_ERR_TAG_UNKNOWN_ATTR;
             _parms->out_error.type = NC_ERR_TYPE_PROTOCOL;
             g_hash_table_insert (_parms->out_error.info, "bad-element", g_strdup ("operation"));
@@ -1366,7 +1365,7 @@ exit:
 GNode *
 sch_xpath_to_gnode (sch_instance * instance, sch_node * schema, const char *path, int flags, sch_node ** rschema, xpath_type *x_type, char *schema_path)
 {
-    GNode *node;
+    GNode *node = NULL;
     char *ptr;
     int len;
     char *_path = NULL;

--- a/netconf.c
+++ b/netconf.c
@@ -1121,6 +1121,22 @@ xpath_evaluate (struct netconf_session *session, xmlNode *rpc, char *path, char 
         xml = NULL;
     }
 
+    /* Clear the reference to the query node maintained by the xmlXPathObject
+     * as a workaround to prevent an invalid read memory access inside the
+     * xmlXPathFreeObject routine
+     **/
+    if (xpath_obj && xpath_obj->nodesetval)
+    {
+        for (int i = 0; i < xpath_obj->nodesetval->nodeNr; i++)
+        {
+            if ((xpath_obj->nodesetval->nodeTab[i] != NULL) &&
+                    (xpath_obj->nodesetval->nodeTab[i]->type == XML_NAMESPACE_DECL))
+            {
+                xpath_obj->nodesetval->nodeTab[i]->_private = NULL;
+            }
+        }
+    }
+
     xmlXPathFreeObject(xpath_obj);
     xmlXPathFreeContext(xpath_ctx);
 


### PR DESCRIPTION
Fixed invalid memory read errors due to accessing
previously freed address spaces.

Also, fixed an unintialised variable usage error.

```
data.c: In function ‘sch_xpath_to_gnode’:
data.c:1433:12: error: ‘node’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1433 |     return node;
      |            ^~~~
cc1: all warnings being treated as errors
make: *** [Makefile:512: apteryx_netconf-data.o] Error 1
```