### PR TITLE
With edit-config don't write the tree if only using deletes or removes

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -186,6 +186,7 @@ GList *sch_parm_removes (sch_xml_to_gnode_parms parms);
 GList *sch_parm_creates (sch_xml_to_gnode_parms parms);
 GList *sch_parm_replaces (sch_xml_to_gnode_parms parms);
 GList *sch_parm_merges (sch_xml_to_gnode_parms parms);
+bool sch_parm_need_tree_set (sch_xml_to_gnode_parms parms);
 void sch_parm_free (sch_xml_to_gnode_parms parms);
 GNode *sch_xpath_to_gnode (sch_instance * instance, sch_node * schema, const char *path, int flags,
                            sch_node ** rschema, xpath_type *x_type, char *schema_path);


### PR DESCRIPTION
The handling of edit config processing needs a re-write. In the interim this change stops a write of the edit-config tree if only deletes or removes have been requested.