### PR TITLE
Fix RFC6020 compliance of identityref value types

### DIFF
--- a/data.c
+++ b/data.c
@@ -319,8 +319,27 @@ _sch_gnode_to_xml (sch_instance * instance, sch_node * schema, sch_ns *ns, xmlNo
         if (!(flags & SCH_F_CONFIG) || sch_is_writable (schema))
         {
             char *value = g_strdup (APTERYX_VALUE (node) ? APTERYX_VALUE (node) : "");
+            xmlChar *idref_href;
+            xmlChar *idref_prefix;
+
             data = xmlNewNode (NULL, BAD_CAST name);
             value = sch_translate_to (schema, value);
+            idref_href = xmlGetProp ((xmlNode *) schema, BAD_CAST "idref_href");
+            if (idref_href)
+            {
+                char *temp = value;
+                idref_prefix = xmlGetProp ((xmlNode *) schema, BAD_CAST "idref_prefix");
+                if (idref_prefix)
+                {
+                    value = g_strdup_printf ("%s:%s", (char *) idref_prefix, value);
+                    xmlNs *nns = xmlNewNs (data, idref_href, NULL);
+                    xmlSetNs (data, nns);
+                    g_free (temp);
+                    xmlFree (idref_prefix);
+                }
+                xmlFree (idref_href);
+            }
+
             xmlNodeSetContent (data, (const xmlChar *) value);
             if (parent)
                 xmlAddChildList (parent, data);

--- a/tests/test_edit_config.py
+++ b/tests/test_edit_config.py
@@ -380,7 +380,7 @@ def test_edit_config_replace_one_full():
 </config>
 """
     xml = _edit_config_test(payload, post_xpath='/test/animals', inc_str=["cat", "dog", "mouse"])
-    assert xml.find('./{*}test/{*}animals/{*}animal[{*}name="cat"]/{*}type').text == 'little'
+    assert xml.find('./{*}test/{*}animals/{*}animal[{*}name="cat"]/{*}type').text == 'a-types:little'
     assert xml.find('./{*}test/{*}animals/{*}animal[{*}name="cat"]/{*}colour').text == 'tawny'
 
 

--- a/tests/test_get_subtree.py
+++ b/tests/test_get_subtree.py
@@ -215,7 +215,7 @@ def test_get_subtree_list_container():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
       <animal>
         <name>dog</name>
@@ -223,7 +223,7 @@ def test_get_subtree_list_container():
       </animal>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <food>
           <name>banana</name>
           <type>fruit</type>
@@ -235,12 +235,12 @@ def test_get_subtree_list_container():
       </animal>
       <animal>
         <name>mouse</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <colour>grey</colour>
       </animal>
       <animal>
         <name>parrot</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
         <colour>blue</colour>
         <toys>
           <toy>puzzles</toy>
@@ -262,7 +262,7 @@ def test_get_subtree_list_element():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
       <animal>
         <name>dog</name>
@@ -270,7 +270,7 @@ def test_get_subtree_list_element():
       </animal>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <food>
           <name>banana</name>
           <type>fruit</type>
@@ -282,12 +282,12 @@ def test_get_subtree_list_element():
       </animal>
       <animal>
         <name>mouse</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <colour>grey</colour>
       </animal>
       <animal>
         <name>parrot</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
         <colour>blue</colour>
         <toys>
           <toy>puzzles</toy>
@@ -337,22 +337,22 @@ def test_get_subtree_selection_multi():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
       <animal>
         <name>dog</name>
       </animal>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
       </animal>
       <animal>
         <name>mouse</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
       </animal>
       <animal>
         <name>parrot</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
     </animals>
   </test>
@@ -369,7 +369,7 @@ def test_get_subtree_select_one_node():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -388,7 +388,7 @@ def test_get_subtree_select_one_with_colon():
         <animals>
             <animal>
                 <name>cat:ty</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -405,7 +405,7 @@ def test_get_subtree_select_one_elements():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -433,7 +433,7 @@ def test_get_subtree_select_multi():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
             <animal>
                 <name>dog</name>
@@ -454,7 +454,7 @@ def test_get_subtree_select_attr_named_only():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -471,7 +471,7 @@ def test_get_subtree_select_attr_named_element():
         <animals>
             <animal>
                 <name>mouse</name>
-                <type>little</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
             </animal>
         </animals>
     </test>
@@ -491,16 +491,16 @@ def test_get_subtree_select_no_key_other_field():
     <test xmlns="http://test.com/ns/yang/testing">
         <animals>
             <animal>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
             <animal>
-                <type>little</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
             </animal>
             <animal>
-                <type>little</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
             </animal>
             <animal>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -520,16 +520,16 @@ def test_get_subtree_select_no_key_other_field_value():
     <test xmlns="http://test.com/ns/yang/testing">
         <animals>
             <animal>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
             <animal>
-                <type>little</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
             </animal>
             <animal>
-                <type>little</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
             </animal>
             <animal>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -549,11 +549,11 @@ def test_get_subtree_select_key_other_field_value():
         <animals>
             <animal>
                 <name>hamster</name>
-                <type>little</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
             </animal>
             <animal>
                 <name>mouse</name>
-                <type>little</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
             </animal>
         </animals>
     </test>
@@ -582,7 +582,7 @@ def test_get_subtree_select_key_value_other_field_value():
         <animals>
             <animal>
                 <name>mouse</name>
-                <type>little</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
             </animal>
         </animals>
     </test>
@@ -623,7 +623,7 @@ def test_get_multi_subtree_select_multi():
     xml = m.get(select).data
     print(etree.tostring(xml, pretty_print=True, encoding="unicode"))
     assert xml.find('./{*}test/{*}animals/{*}animal/{*}name').text == 'cat'
-    assert xml.find('./{*}test/{*}animals/{*}animal[{*}name="cat"]/{*}type').text == 'big'
+    assert xml.find('./{*}test/{*}animals/{*}animal[{*}name="cat"]/{*}type').text == 'a-types:big'
     assert xml.find('./{*}interfaces/{*}interface[{*}name="eth2"]/{*}mtu').text == '9000'
     m.close_session()
 
@@ -703,11 +703,11 @@ def test_get_subtree_select_key_value_other_field_exp_two_results():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
             <animal>
                 <name>parrot</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -748,7 +748,7 @@ def test_get_subtree_proxy_named_element():
         <animals>
           <animal>
             <name>mouse</name>
-            <type>little</type>
+            <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
           </animal>
         </animals>
       </test>

--- a/tests/test_get_xpath.py
+++ b/tests/test_get_xpath.py
@@ -196,7 +196,7 @@ def test_get_xpath_list_trunk():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
       <animal>
         <name>dog</name>
@@ -204,7 +204,7 @@ def test_get_xpath_list_trunk():
       </animal>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <food>
           <name>banana</name>
           <type>fruit</type>
@@ -216,12 +216,12 @@ def test_get_xpath_list_trunk():
       </animal>
       <animal>
         <name>mouse</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <colour>grey</colour>
       </animal>
       <animal>
         <name>parrot</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
         <colour>blue</colour>
         <toys>
           <toy>puzzles</toy>
@@ -243,7 +243,7 @@ def test_get_xpath_list_select_one_trunk():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -260,7 +260,7 @@ def test_get_xpath_list_select_one_trunk_with_child():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -277,7 +277,7 @@ def test_get_xpath_list_select_one_parameter():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -294,7 +294,7 @@ def test_get_xpath_list_select_one_parameter_double_quotes():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -311,7 +311,7 @@ def test_get_xpath_list_select_one_parameter_double_quotes_with_child():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -328,7 +328,7 @@ def test_get_xpath_query_multi_with_child():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
     </animals>
   </test>
@@ -353,7 +353,7 @@ def test_get_xpath_query_multi():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
     </animals>
   </test>
@@ -378,7 +378,7 @@ def test_get_xpath_multi_select_multi():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
     </animals>
   </test>
@@ -544,7 +544,7 @@ def test_get_xpath_multi_xpath_select_multi():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
     </animals>
   </test>
@@ -568,7 +568,7 @@ def test_get_xpath_with_slash_slash():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
       <animal>
         <name>dog</name>
@@ -576,7 +576,7 @@ def test_get_xpath_with_slash_slash():
       </animal>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <food>
           <name>banana</name>
           <type>fruit</type>
@@ -588,12 +588,12 @@ def test_get_xpath_with_slash_slash():
       </animal>
       <animal>
         <name>mouse</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <colour>grey</colour>
       </animal>
       <animal>
         <name>parrot</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
         <colour>blue</colour>
         <toys>
           <toy>puzzles</toy>
@@ -616,7 +616,7 @@ def test_get_xpath_with_slash_slash_bad_ns():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
       <animal>
         <name>dog</name>
@@ -624,7 +624,7 @@ def test_get_xpath_with_slash_slash_bad_ns():
       </animal>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <food>
           <name>banana</name>
           <type>fruit</type>
@@ -636,12 +636,12 @@ def test_get_xpath_with_slash_slash_bad_ns():
       </animal>
       <animal>
         <name>mouse</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <colour>grey</colour>
       </animal>
       <animal>
         <name>parrot</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
         <colour>blue</colour>
         <toys>
           <toy>puzzles</toy>
@@ -733,7 +733,7 @@ def test_get_xpath_with_name_first():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
     </animals>
   </test>
@@ -750,7 +750,7 @@ def test_get_xpath_with_name_last():
     <animals>
       <animal>
         <name>parrot</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
         <colour>blue</colour>
         <toys>
           <toy>puzzles</toy>
@@ -5863,7 +5863,7 @@ def test_get_xpath_relative_path():
         <animals>
             <animal>
                 <name>cat</name>
-                <type>big</type>
+                <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
             </animal>
         </animals>
     </test>
@@ -5880,7 +5880,7 @@ def test_get_xpath_relative_path_dot_dot():
     <animals>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <food>
           <name>banana</name>
           <type>fruit</type>
@@ -5937,7 +5937,7 @@ def test_get_xpath_relative_path_dot_dot_field_dot_dot():
     <animals>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <food>
           <name>banana</name>
           <type>fruit</type>
@@ -5962,7 +5962,7 @@ def test_get_xpath_relative_path_dot_dot_dot_dot():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
       <animal>
         <name>dog</name>
@@ -5970,7 +5970,7 @@ def test_get_xpath_relative_path_dot_dot_dot_dot():
       </animal>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <food>
           <name>banana</name>
           <type>fruit</type>
@@ -5982,12 +5982,12 @@ def test_get_xpath_relative_path_dot_dot_dot_dot():
       </animal>
       <animal>
         <name>mouse</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <colour>grey</colour>
       </animal>
       <animal>
         <name>parrot</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
         <colour>blue</colour>
         <toys>
           <toy>puzzles</toy>
@@ -6102,7 +6102,7 @@ def test_get_xpath_list_entry_leaf_node_1():
         <animals>
           <animal>
             <name>hamster</name>
-            <type>little</type>
+            <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
             <food>
               <name>banana</name>
               <type>fruit</type>
@@ -6229,7 +6229,7 @@ def test_get_xpath_proxy_list_select_one_trunk():
         <animals>
           <animal>
             <name>cat</name>
-            <type>big</type>
+            <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
           </animal>
         </animals>
       </test>

--- a/tests/test_with_defaults.py
+++ b/tests/test_with_defaults.py
@@ -402,16 +402,16 @@ def test_with_default_report_all_on_empty_branch():
     <animals>
       <animal>
         <name>cat</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
       </animal>
       <animal>
         <name>dog</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
         <colour>brown</colour>
       </animal>
       <animal>
         <name>hamster</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <food>
           <name>banana</name>
           <type>fruit</type>
@@ -423,12 +423,12 @@ def test_with_default_report_all_on_empty_branch():
       </animal>
       <animal>
         <name>mouse</name>
-        <type>little</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:little</type>
         <colour>grey</colour>
       </animal>
       <animal>
         <name>parrot</name>
-        <type>big</type>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
         <colour>blue</colour>
         <toys>
           <toy>puzzles</toy>


### PR DESCRIPTION
The current code is not compliant to Netconf RFC - RFC6020 https://datatracker.ietf.org/doc/html/rfc6020#section-9.10.5

This change uses the new information generated by pyang-apteryx-xml.py to display identityref types as per the RFC.