### PR TITLE
Fix an xpath issue with record selecting numeric predicates

### DIFF
--- a/data.c
+++ b/data.c
@@ -1282,6 +1282,10 @@ _sch_xpath_to_gnode (sch_instance * instance, sch_node ** rschema, sch_node ** v
             pred = g_strdup (pred);
             free (name);
             name = temp;
+
+            /* Numeric predicates to a record offset must be evaluated */
+            if (isdigit (pred[1]))
+                *x_type = XPATH_EVALUATE;
         }
 
         if (schema && vschema && *vschema == NULL && sch_is_list (schema))

--- a/tests/test_get_xpath.py
+++ b/tests/test_get_xpath.py
@@ -6333,3 +6333,20 @@ def test_get_xpath_must_condition_false():
 </nc:data>
     """
     _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_list_trunk_predicate_one():
+    xpath = '/test/animals/animal[1]'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test xmlns="http://test.com/ns/yang/testing">
+    <animals>
+      <animal>
+        <name>cat</name>
+        <type xmlns="http://test.com/ns/yang/animal-types">a-types:big</type>
+      </animal>
+    </animals>
+  </test>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')


### PR DESCRIPTION
Predicates of the type /field1/field2/field3[n] were not being evaluated by the libxml2 xpath evaluation routine, and hence all matching records to /field1/field2/field3/* were being returned.

This has been fixed.