### PR TITLE
Add support for loading and unloading models and model features

### DIFF
--- a/netconf.c
+++ b/netconf.c
@@ -597,38 +597,104 @@ static void
 schema_set_model_information (xmlNode * cap)
 {
     xmlNode *xml_child;
-    sch_loaded_model *loaded;
-    GList *list;
     char *capability;
-    GList *loaded_models = sch_get_loaded_models (g_schema);
+    GNode *query = APTERYX_NODE (NULL, g_strdup_printf ("%s/*", YANG_LIBRARY_MOD_SET_COMMON_MOD));
+    GNode *tree = apteryx_query (query);
 
-    for (list = g_list_first (loaded_models); list; list = g_list_next (list))
+    if (tree)
     {
-        loaded = list->data;
-        if (loaded->organization && loaded->version && loaded->model &&
-            strlen (loaded->organization) && strlen (loaded->version) &&
-            strlen (loaded->model))
+        for (GNode *child = tree->children; child; child = child->next)
         {
-            char *old;
-            xml_child = xmlNewChild (cap, NULL, BAD_CAST "capability", NULL);
-            capability = g_strdup_printf ("%s?module=%s&amp;revision=%s",
-                                          loaded->ns_href, loaded->model, loaded->version);
-            if (loaded->features)
+            char *model = NULL;
+            char *revision = NULL;
+            char *ns_href = NULL;
+            char *features = NULL;
+            char *deviations = NULL;
+
+            for (GNode *info = child->children; info; info = info->next)
             {
-                old = capability;
-                capability = g_strdup_printf ("%s&amp;features=%s", capability, loaded->features);
-                g_free (old);
+                if (g_strcmp0 ((char *) info->data, "name") == 0 && info->children)
+                {
+                    model = (char *) info->children->data;
+                }
+                else if (g_strcmp0 ((char *) info->data, "namespace") == 0 && info->children)
+                {
+                    ns_href = (char *) info->children->data;
+                }
+                else if (g_strcmp0 ((char *) info->data, "revision") == 0 && info->children)
+                {
+                    revision = (char *) info->children->data;
+                }
+                else if (g_strcmp0 ((char *) info->data, "feature") == 0 && info->children)
+                {
+                    GList *feat_list = NULL;
+                    for (GNode *list = info->children; list; list = list->next)
+                    {
+                        feat_list = g_list_prepend (feat_list, list->data);
+                    }
+                    if (feat_list)
+                    {
+                        feat_list = g_list_sort (feat_list, (GCompareFunc) g_strcmp0);
+                        for (GList *iter =g_list_first (feat_list); iter; iter = g_list_next (iter))
+                        {
+                            if (features)
+                            {
+                                char *temp = features;
+                                features = g_strdup_printf ("%s,%s", features, (char *) iter->data);
+                                g_free (temp);
+                            }
+                            else
+                            {
+                                features = g_strdup ((char *) iter->data);
+                            }
+                        }
+                        g_list_free (feat_list);
+                    }
+                }
+                else if (g_strcmp0 ((char *) info->data, "deviation") == 0 && info->children)
+                {
+                    for (GNode *list = info->children; list; list = list->next)
+                    {
+                        if (deviations)
+                        {
+                            char *temp = deviations;
+                            deviations = g_strdup_printf ("%s,%s", deviations, (char *) list->data);
+                            g_free (temp);
+                        }
+                        else
+                        {
+                            deviations = g_strdup ((char *) list->data);
+                        }
+                    }
+                }
             }
-            if (loaded->deviations)
+            if (ns_href && revision && model)
             {
-                old = capability;
-                capability = g_strdup_printf ("%s&amp;deviations=%s", capability, loaded->deviations);
-                g_free (old);
+                char *old;
+                xml_child = xmlNewChild (cap, NULL, BAD_CAST "capability", NULL);
+                capability = g_strdup_printf ("%s?module=%s&amp;revision=%s",
+                                              ns_href, model, revision);
+                if (features)
+                {
+                    old = capability;
+                    capability = g_strdup_printf ("%s&amp;features=%s", capability, features);
+                    g_free (old);
+                }
+                if (deviations)
+                {
+                    old = capability;
+                    capability = g_strdup_printf ("%s&amp;deviations=%s", capability, deviations);
+                    g_free (old);
+                }
+                xmlNodeSetContent (xml_child, BAD_CAST capability);
+                g_free (capability);
             }
-            xmlNodeSetContent (xml_child, BAD_CAST capability);
-            g_free (capability);
+            g_free (features);
+            g_free (deviations);
         }
+        apteryx_free_tree (tree);
     }
+    apteryx_free_tree (query);
 }
 
 static bool
@@ -2732,11 +2798,21 @@ netconf_handle_session (int fd)
     return NULL;
 }
 
+static bool
+netconf_yang_library_callback (const char *model, int flags, const char *features)
+{
+    return sch_update_model (g_schema, model, flags, features);
+}
+
 bool
 netconf_init (const char *path, const char *supported,  const char *cp, const char *rm)
 {
+
+    /* Initialize the yang library */
+    yang_library_init (netconf_yang_library_callback);
+
     /* Load Data Models */
-    g_schema = sch_load_with_model_list_filename (path, supported);
+    g_schema = sch_load_model_list_yang_library (path, false);
     if (!g_schema)
     {
         return false;
@@ -2765,6 +2841,8 @@ netconf_init (const char *path, const char *supported,  const char *cp, const ch
 void
 netconf_shutdown (void)
 {
+    yang_library_shutdown ();
+
     /* Cleanup datamodels */
     if (g_schema)
         sch_free (g_schema);

--- a/tests/test_netconf.py
+++ b/tests/test_netconf.py
@@ -25,7 +25,7 @@ def test_server_capabilities():
     assert ":interleave" not in m.server_capabilities
     assert ":session-id" not in m.server_capabilities
     # Supported models - first is default namespace
-    assert "http://test.com/ns/yang/testing?module=testing&revision=2023-01-01&features=test-time,dummy" in m.server_capabilities
+    assert "http://test.com/ns/yang/testing?module=testing&revision=2023-01-01&features=dummy,test-time" in m.server_capabilities
     assert "http://test.com/ns/yang/testing-2?module=testing-2&revision=2023-02-01" in m.server_capabilities
     assert "http://test.com/ns/yang/testing2-augmented?module=testing2-augmented&revision=2023-02-02" in m.server_capabilities
     m.close_session()


### PR DESCRIPTION
This changes allows loaded models to be unloaded if not required and reloaded at a later point if  required again. Features can now also be added or removed dynamically from a loaded model.

The help message capabilities are now derived from the yang-library data.