### PR TITLE
Fix processing of lists at the top-level

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -151,7 +151,7 @@ rc=$?; if [[ $rc != 0 ]]; then quit $rc; fi
 sleep 0.5
 cd $BUILD/../
 
-if [ $ACTION == "test" ]; then
+if [ "$ACTION" == "test" ]; then
         python3 -m pytest -v
         rc=$?; if [[ $rc != 0 ]]; then quit $rc; fi
 fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,6 +191,8 @@ def run_around_tests():
     os.system("echo Before test")
     os.system("%s -r /test" % (APTERYX))
     apteryx_prune("/test")
+    apteryx_prune("/test-list")
+    apteryx_prune("/test-leaflist")
     apteryx_prune("/t2:test")
     for path, value in db_default:
         apteryx_set(path, value)
@@ -198,6 +200,8 @@ def run_around_tests():
     # After test
     os.system("echo After test")
     apteryx_prune("/test")
+    apteryx_prune("/test-list")
+    apteryx_prune("/test-leaflist")
     apteryx_prune("/t2:test")
 
 

--- a/tests/test_edit_config.py
+++ b/tests/test_edit_config.py
@@ -137,6 +137,19 @@ def test_edit_config_list():
     _edit_config_test(payload, post_xpath="/test/animals", inc_str=["frog"])
 
 
+def test_edit_config_toplevel_list():
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test-list>
+    <index>1</index>
+    <name>frog</name>
+  </test-list>
+</config>
+"""
+    _edit_config_test(payload, post_xpath="/test-list", inc_str=["frog"])
+
+
 def test_edit_config_list_key_colon():
     payload = """
 <config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
@@ -259,6 +272,20 @@ def test_edit_config_delete_list():
 </config>
 """
     _edit_config_test(payload, post_xpath="/test/animals", exc_str=["cat"])
+
+
+def test_edit_config_delete_toplevel_list():
+    apteryx_set("/test-list/1/index", "1")
+    apteryx_set("/test-list/1/name", "cat")
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test-list xc:operation="delete">
+    <index>1</index>
+  </test-list>
+</config>
+"""
+    _edit_config_test(payload, post_xpath="/test-list", exc_str=["cat"])
 
 
 def test_edit_config_delete_leaf_list_item():
@@ -520,6 +547,16 @@ def test_edit_config_create_leaf_list_item():
     _edit_config_test(payload, post_xpath="/test/animals/animal/parrot/toys", inc_str=["bell"])
 
 
+def test_edit_config_create_toplevel_leaf_list_item():
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test-leaflist xmlns="http://test.com/ns/yang/testing" xc:operation="create">bell</test-leaflist>
+</config>
+"""
+    _edit_config_test(payload, post_xpath="/test-leaflist", inc_str=["bell"])
+
+
 # EDIT-CONFIG (operation=remove)
 #  remove:  The configuration data identified by the element
 #     containing this attribute is deleted from the configuration
@@ -577,6 +614,17 @@ def test_edit_config_remove_leaf_list_item():
 </config>
 """
     _edit_config_test(payload, post_xpath="/test/animals/animal/parrot/toys", inc_str=["puzzles"], exc_str=["rings"])
+
+
+def test_edit_config_remove_toplevel_leaf_list_item():
+    apteryx_set("/test-leaflist/cat", "cat")
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test-leaflist xmlns="http://test.com/ns/yang/testing" xc:operation="remove">cat</test-leaflist>
+</config>
+"""
+    _edit_config_test(payload, post_xpath="/test-leaflist", exc_str=["cat"])
 
 
 # Empty value for nodes that have a non-empty pattern or values

--- a/tests/test_get_subtree.py
+++ b/tests/test_get_subtree.py
@@ -254,6 +254,34 @@ def test_get_subtree_list_container():
     _get_test_with_filter(select, expected)
 
 
+def test_get_subtree_toplevel_list():
+    apteryx_set("/test-list/1/index", "1")
+    apteryx_set("/test-list/1/name", "cat")
+    select = '<test-list/>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test-list xmlns="http://test.com/ns/yang/testing">
+      <index>1</index>
+      <name>cat</name>
+    </test-list>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_toplevel_leaflist():
+    apteryx_set("/test-leaflist/cat", "cat")
+    apteryx_set("/test-leaflist/dog", "dog")
+    select = '<test-leaflist/>'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test-leaflist xmlns="http://test.com/ns/yang/testing">cat</test-leaflist>
+    <test-leaflist xmlns="http://test.com/ns/yang/testing">dog</test-leaflist>
+</nc:data>
+    """
+    _get_test_with_filter(select, expected)
+
+
 def test_get_subtree_list_element():
     select = '<test><animals><animal/></animals></test>'
     expected = """

--- a/tests/test_get_xpath.py
+++ b/tests/test_get_xpath.py
@@ -235,6 +235,48 @@ def test_get_xpath_list_trunk():
     _get_test_with_filter(xpath, expected, f_type='xpath')
 
 
+def test_get_xpath_toplevel_list_all():
+    apteryx_set("/test-list/1/index", "1")
+    apteryx_set("/test-list/1/name", "cat")
+    apteryx_set("/test-list/3/index", "3")
+    apteryx_set("/test-list/3/name", "mouse")
+    apteryx_set("/test-list/2/index", "2")
+    apteryx_set("/test-list/2/name", "dog")
+    xpath = '/test-list'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test-list xmlns="http://test.com/ns/yang/testing">
+      <index>1</index>
+      <name>cat</name>
+    </test-list>
+    <test-list xmlns="http://test.com/ns/yang/testing">
+      <index>2</index>
+      <name>dog</name>
+    </test-list>
+    <test-list xmlns="http://test.com/ns/yang/testing">
+      <index>3</index>
+      <name>mouse</name>
+    </test-list>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_toplevel_leaflist():
+    apteryx_set("/test-leaflist/cat", "cat")
+    apteryx_set("/test-leaflist/mouse", "mouse")
+    apteryx_set("/test-leaflist/dog", "dog")
+    xpath = '/test-leaflist'
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test-leaflist xmlns="http://test.com/ns/yang/testing">cat</test-leaflist>
+    <test-leaflist xmlns="http://test.com/ns/yang/testing">dog</test-leaflist>
+    <test-leaflist xmlns="http://test.com/ns/yang/testing">mouse</test-leaflist>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
 def test_get_xpath_list_select_one_trunk():
     xpath = "/test/animals/animal[name='cat']"
     expected = """
@@ -247,6 +289,23 @@ def test_get_xpath_list_select_one_trunk():
             </animal>
         </animals>
     </test>
+</nc:data>
+    """
+    _get_test_with_filter(xpath, expected, f_type='xpath')
+
+
+def test_get_xpath_toplevel_list_select_one():
+    apteryx_set("/test-list/1/index", "1")
+    apteryx_set("/test-list/1/name", "cat")
+    apteryx_set("/test-list/2/index", "2")
+    apteryx_set("/test-list/2/name", "dog")
+    xpath = "/test-list[index='2']"
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <test-list xmlns="http://test.com/ns/yang/testing">
+      <index>2</index>
+      <name>dog</name>
+    </test-list>
 </nc:data>
     """
     _get_test_with_filter(xpath, expected, f_type='xpath')


### PR DESCRIPTION
Both lists and leaf lists as root nodes.
Results in top level xml with siblings rather than children. Fix edit-config so that the root / is added to each node. Remove duplicated debug in _sch_xpath_to_gnode
Small fixup in run.sh to avoid warning.
Tests for create, delete, and get of toplevel lists