### PR TITLE
Tree from XML should not have duplicate nodes

### DIFF
--- a/data.c
+++ b/data.c
@@ -956,7 +956,33 @@ _sch_xml_to_gnode (_sch_xml_to_gnode_parms *_parms, sch_node * schema, sch_ns *n
             if (cn)
             {
                 if (node)
-                    g_node_append (node, cn);
+                {
+                    GNode *sub_node;
+                    GNode *sub_cn;
+                    GNode *next_sub_cn = NULL;
+
+                    /* If we already have a child matching the top of the new data, add the data to that
+                     * node so we don't get multiple entries at any level.
+                     * If the data is NULL, just ignore the new data.
+                     */
+                    if ((sub_node = apteryx_find_child (node, cn->data)) != NULL)
+                    {
+                        for (sub_cn = cn->children; sub_cn; sub_cn = next_sub_cn)
+                        {
+                            next_sub_cn = sub_cn->next;
+                            sub_cn->parent = NULL;
+                            sub_cn->next = NULL;
+                            sub_cn->prev = NULL;
+                            g_node_append (sub_node, sub_cn);
+                        }
+                        cn->children = NULL;
+                        apteryx_free_tree (cn);
+                    }
+                    else
+                    {
+                        g_node_append (node, cn);
+                    }
+                }
                 else
                     tree = cn;
                 ret_tree = true;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,8 @@ db_default = [
     ('/test/settings/users/bob/active', 'true'),
     ('/test/settings/users/bob/groups/2', '2'),
     ('/test/settings/users/bob/groups/23', '23'),
+    ('/test/settings/users/bob/groups/24', '24'),
+    ('/test/settings/users/bob/groups/25', '25'),
 ]
 
 

--- a/tests/test_get_subtree.py
+++ b/tests/test_get_subtree.py
@@ -190,6 +190,8 @@ def test_get_subtree_trunk():
                 <active>true</active>
                 <groups>2</groups>
                 <groups>23</groups>
+                <groups>24</groups>
+                <groups>25</groups>
             </users>
             <volume>1</volume>
         </settings>

--- a/tests/test_get_xpath.py
+++ b/tests/test_get_xpath.py
@@ -186,6 +186,8 @@ def test_get_xpath_trunk():
                 <active>true</active>
                 <groups>2</groups>
                 <groups>23</groups>
+                <groups>24</groups>
+                <groups>25</groups>
             </users>
             <volume>1</volume>
         </settings>


### PR DESCRIPTION
When adding subtress to a GNode tree ensure that if the root of the tree being added is already a sub-node of the node to which the subtree is to be added, that we add the subtree under the existing node (removing the top of the subtree to do so).

This is not something that can be explicitly tested, but add some tests to at least ensure that the new code doesn't cause any problems.