### PR TITLE
Add logging for close-session requests

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -69,6 +69,7 @@ typedef enum
     LOG_KILL_SESSION            = (1 << 3),  /* Log kill-session requests */
     LOG_LOCK                    = (1 << 4),  /* Log lock requests */
     LOG_UNLOCK                  = (1 << 5),  /* Log unlock requests */
+    LOG_CLOSE_SESSION           = (1 << 6),  /* Log close-session requests */
 } logging_flags;
 
 /* Define session counters from the RFC 6022 /netconf-state/sessions group

--- a/logging.c
+++ b/logging.c
@@ -67,6 +67,8 @@ load_logging_options (void)
                     flags |= LOG_LOCK;
                 else if (g_strcmp0 (split[i], "unlock") == 0)
                     flags |= LOG_UNLOCK;
+                else if (g_strcmp0 (split[i], "close-session") == 0)
+                    flags |= LOG_CLOSE_SESSION;
             }
             g_strfreev (split);
         }

--- a/netconf.c
+++ b/netconf.c
@@ -2716,6 +2716,9 @@ netconf_handle_session (int fd)
         if (g_strcmp0 ((char *) child->name, "close-session") == 0)
         {
             VERBOSE ("Closing session\n");
+            if ((logging & LOG_CLOSE_SESSION))
+                NOTICE ("CLOSE-SESSION: %s@%s id:%d closed\n",
+                        session->username, session->rem_addr, session->id);
             send_rpc_ok (session, rpc, true);
             xmlFreeDoc (doc);
             g_free (message);

--- a/tests/test_edit_config.py
+++ b/tests/test_edit_config.py
@@ -1055,6 +1055,44 @@ def test_edit_config_when_path_exists():
     assert xml.find('./{*}test/{*}settings/{*}complextime/{*}days').text == '2'
 
 
+def test_edit_config_when_condition_translate_true():
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test>
+    <animals>
+        <animal>
+            <name>cat</name>
+            <cages>
+              <cage>box</cage>
+            </cages>
+        </animal>
+    </animals>
+  </test>
+</config>
+"""
+    _edit_config_test(payload, post_xpath="/test/animals/animal[name='cat']", inc_str=["box"])
+
+
+def test_edit_config_when_condition_translate_false():
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test>
+    <animals>
+        <animal>
+            <name>mouse</name>
+            <cages>
+              <cage>box</cage>
+            </cages>
+        </animal>
+    </animals>
+  </test>
+</config>
+"""
+    _edit_config_test(payload, expect_err={"tag": "invalid-value", "type": "protocol"})
+
+
 def test_edit_config_must_condition_true():
     payload = """
 <config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"


### PR DESCRIPTION
Logging of close-session requests was missed when support for the netconf logging options was originally written.

This change adds support for logging close-session requests.

Additionally some further tests for the "when" condition have been added.