### PR TITLE
edit-config: merge with just list index should work

### DIFF
--- a/data.c
+++ b/data.c
@@ -911,21 +911,11 @@ _sch_xml_to_gnode (_sch_xml_to_gnode_parms *_parms, sch_node * schema, sch_ns *n
                 {
                     node = APTERYX_NODE (tree, value);
                     DEBUG ("%*s%s = %s\n", depth * 2, " ", name, APTERYX_NAME (node));
-
                     if (_parms->in_is_edit)
                     {
-                        bool is_key = false;
-
-                        if (sch_parent && sch_is_list (sch_parent) &&
-                            (schema == sch_node_child_first (sch_node_child_first (sch_parent))))
-                            is_key = true;
-
-                        if (!is_key)
-                        {
-                            _parms->out_merges =
-                                g_list_append (_parms->out_merges, g_strdup_printf ("%s/%s", new_xpath, value));
-                            DEBUG ("merge <%s>\n", new_xpath);
-                        }
+                        _parms->out_merges =
+                            g_list_append (_parms->out_merges, g_strdup_printf ("%s/%s", new_xpath, value));
+                        DEBUG ("merge <%s>\n", new_xpath);
                     }
                 }
             }

--- a/tests/test_edit_config.py
+++ b/tests/test_edit_config.py
@@ -138,6 +138,74 @@ def test_edit_config_list():
     _edit_config_test(payload, post_xpath="/test/animals", inc_str=["frog"])
 
 
+def test_edit_config_list_just_index():
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test>
+    <animals>
+        <animal>
+            <name>polar bear</name>
+        </animal>
+    </animals>
+  </test>
+</config>
+"""
+    _edit_config_test(payload, post_xpath="/test/animals", inc_str=["polar bear"])
+
+
+def test_edit_config_list_just_index_twice():
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test>
+    <animals>
+        <animal>
+            <name>polar bear</name>
+        </animal>
+    </animals>
+  </test>
+</config>
+"""
+    _edit_config_test(payload, post_xpath="/test/animals", inc_str=["polar bear"])
+    _edit_config_test(payload, post_xpath="/test/animals", inc_str=["polar bear"])
+
+
+def test_edit_config_list_double_index():
+    """
+    Create a list entry with a merge, then send a merge request on that entry with
+    another index variable in the message. The original list entry should remain
+    unchanges.
+    """
+    pl1 = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test>
+    <animals>
+        <animal>
+            <name>polar bear</name>
+        </animal>
+    </animals>
+  </test>
+</config>
+"""
+    pl2 = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test>
+    <animals>
+        <animal>
+            <name>polar bear</name>
+            <name>big white bear</name>
+        </animal>
+    </animals>
+  </test>
+</config>
+"""
+    _edit_config_test(pl1, post_xpath="/test/animals", inc_str=["polar bear"])
+    _edit_config_test(pl2, post_xpath="/test/animals", inc_str=["polar bear"])
+
+
 def test_edit_config_toplevel_list():
     payload = """
 <config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"


### PR DESCRIPTION
A merge request creating a new list entry with only the list index present in the message should work. It was actually being filtered out because a merge request for an existing list entry with no other data is a null operation. Rather than check for the existence of the entry (which we would have to do for creates, deletes and replaces) just go ahead and add the index to the merge list, even if it risks having a do-nothing request.