### PR TITLE
Fix and Improve logging

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -180,7 +180,7 @@ sch_instance *netconf_get_g_schema (void);
 xmlNode *sch_gnode_to_xml (sch_instance * instance, sch_node * schema, GNode * node, int flags);
 sch_xml_to_gnode_parms sch_xml_to_gnode (sch_instance * instance, sch_node * schema,
                                          xmlNode * xml, int flags, char * def_op,
-                                         bool is_edit, sch_node **rschema, char ** edit_op);
+                                         bool is_edit, sch_node **rschema);
 GNode *sch_parm_tree (sch_xml_to_gnode_parms parms);
 nc_error_parms sch_parm_error (sch_xml_to_gnode_parms parms);
 GList *sch_parm_deletes (sch_xml_to_gnode_parms parms);


### PR DESCRIPTION
Fixes issue in identifying and logging edit-config merge and replace operations correctly.
Reverts changes introduced by commit-msg 5e5f30fb724225e1f01f79cb39d38ceaf7300f44.

Added debug logging to show the tree paths that correspond to XPath expressions during evaluation. This helps track how XPath queries map to the internal tree structure for debugging purposes.