### PR TITLE
edit-config: Fix issue with mixed merge and delete operations

### DIFF
--- a/data.c
+++ b/data.c
@@ -725,6 +725,8 @@ _sch_xml_to_gnode (_sch_xml_to_gnode_parms *_parms, sch_node * schema, sch_ns *n
                 g_strcmp0 (new_op, "none") == 0)
             {
                 new_xpath = g_strdup_printf ("%s/%s", old_xpath, key_value);
+                apteryx_free_tree (tree);
+                tree = NULL;
             }
             else
             {

--- a/tests/test_edit_config.py
+++ b/tests/test_edit_config.py
@@ -1234,6 +1234,27 @@ def test_edit_config_leaf_list_valid_value():
     _edit_config_test(payload, post_xpath='/test/settings/users[name="bob"]', inc_str=['123', '321'])
 
 
+def test_edit_config_leaf_list_merge_and_delete():
+    """
+    Merge one new leaf-list entry and delete an existing one in the same message.
+    """
+    payload = """
+<config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
+        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <test>
+    <settings>
+      <users>
+        <name>bob</name>
+        <groups xc:operation="delete">23</groups>
+        <groups>24</groups>
+      </users>
+    </settings>
+  </test>
+</config>
+"""
+    _edit_config_test(payload, post_xpath='/test/settings/users[name="bob"]', inc_str=['24'], exc_str=['23'])
+
+
 def test_edit_config_list_missing_index():
     """
     Set merge for new animal without an index, expect an error.


### PR DESCRIPTION
On a leaf-list, having a merge and a delete operation in the same message was causing the merge to be lost, due to a slightly malformed data tree because of the delete operation. Clean this up when detected.

Add a unit test to test this specific case.