### PR TITLE
Fix a "get" subtree issue resulting in a malformed query.

### DIFF
--- a/data.c
+++ b/data.c
@@ -973,11 +973,13 @@ _sch_xml_to_gnode (_sch_xml_to_gnode_parms *_parms, sch_node * schema, sch_ns *n
                 else
                 {
                     /* Want one field in list element for one or more entries */
-                    APTERYX_NODE (node, g_strdup ((const char *) child->name));
+                    GNode *_node = APTERYX_NODE (node, g_strdup ((const char *) child->name));
                     DEBUG ("%*s%s\n", (depth + 1) * 2, " ", child->name);
                     sch_node *child_schema = sch_ns_node_child (ns, schema, (char *) child->name);
                     if (child_schema && rschema)
                         *rschema = child_schema;
+                    if (!_parms->in_is_edit)
+                        g_node_prepend_data (_node, NULL);
                 }
                 break;
             }

--- a/tests/test_with_defaults.py
+++ b/tests/test_with_defaults.py
@@ -705,9 +705,6 @@ def test_with_default_report_all_complex_tree():
       <object>
         <name>fred</name>
         <top-container>
-          <conf>
-            <enabled>true</enabled>
-          </conf>
           <inner-container>
             <conf>
               <enabled>false</enabled>


### PR DESCRIPTION
An issue has been found where translation of the input XML to a query was creating a corrupt subtree query tree.

Fixed the test_with_default_report_all_complex_tree test that was expecting incorrect information.