### PR TITLE
Add support for common yang-library code between restconf and netconf

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -98,8 +98,7 @@ extern GMainLoop *g_loop;
 
 /* Netconf routines */
 void netconf_close_open_sessions (void);
-bool netconf_init (const char *path, const char *supported,
-                   const char *cp, const char *rm);
+bool netconf_init (const char *path, const char *cp, const char *rm);
 void *netconf_handle_session (int fd);
 void netconf_shutdown (void);
 

--- a/main.c
+++ b/main.c
@@ -27,7 +27,6 @@ gboolean apteryx_netconf_debug = FALSE;
 gboolean apteryx_netconf_verbose = FALSE;
 static gboolean background = FALSE;
 static gchar *models_path = "./";
-static gchar *supported = NULL;
 static gchar *logging_arg = NULL;
 static gchar *unix_path = "/tmp/apteryx-netconf";
 static gchar *cp_cmd = NULL;
@@ -95,8 +94,6 @@ static GOptionEntry entries[] = {
     {"background", 'b', 0, G_OPTION_ARG_NONE, &background, "Background", NULL},
     {"models", 'm', 0, G_OPTION_ARG_STRING, &models_path,
      "Path to models(defaults to \"./\")", NULL},
-    {"supported", 's', 0, G_OPTION_ARG_STRING, &supported,
-     "Name of a file containing a list of supported models", NULL},
     {"logging", 'l', 0, G_OPTION_ARG_STRING, &logging_arg,
      "Name of a file containing a list of events to log", NULL},
     {"unix", 'u', 0, G_OPTION_ARG_STRING, &unix_path,
@@ -134,7 +131,7 @@ main (int argc, char *argv[])
 
     /* Initialization */
     apteryx_init (apteryx_netconf_verbose);
-    if (!netconf_init (models_path, supported, cp_cmd, rm_cmd))
+    if (!netconf_init (models_path, cp_cmd, rm_cmd))
     {
         g_error ("Failed to load models from \"%s\"\n", models_path);
     }

--- a/tests/test_netconf.py
+++ b/tests/test_netconf.py
@@ -25,7 +25,7 @@ def test_server_capabilities():
     assert ":interleave" not in m.server_capabilities
     assert ":session-id" not in m.server_capabilities
     # Supported models - first is default namespace
-    assert "http://test.com/ns/yang/testing?module=testing&revision=2023-01-01&features=test-time,dummy" in m.server_capabilities
+    assert "http://test.com/ns/yang/testing?module=testing&revision=2023-01-01&features=dummy,test-time" in m.server_capabilities
     assert "http://test.com/ns/yang/testing-2?module=testing-2&revision=2023-02-01" in m.server_capabilities
     assert "http://test.com/ns/yang/testing2-augmented?module=testing2-augmented&revision=2023-02-02" in m.server_capabilities
     m.close_session()

--- a/tests/test_yang_library.py
+++ b/tests/test_yang_library.py
@@ -1,0 +1,112 @@
+from conftest import _get_test_with_filter, toXML, diffXML
+from lxml import etree
+
+
+# ietf-yang-library
+# module: ietf-yang-library
+#   +--ro yang-library
+#   |  +--ro module-set* [name]
+#   |  |  +--ro name                  string
+#   |  |  +--ro module* [name]
+#   |  |  |  +--ro name         yang:yang-identifier
+#   |  |  |  +--ro revision?    revision-identifier
+#   |  |  |  +--ro namespace    inet:uri
+#   |  |  |  +--ro location*    inet:uri
+#   |  |  |  +--ro submodule* [name]
+#   |  |  |  |  +--ro name        yang:yang-identifier
+#   |  |  |  |  +--ro revision?   revision-identifier
+#   |  |  |  |  +--ro location*   inet:uri
+#   |  |  |  +--ro feature*     yang:yang-identifier
+#   |  |  |  +--ro deviation*   -> ../../module/name
+#   |  |  +--ro import-only-module* [name revision]
+#   |  |     +--ro name         yang:yang-identifier
+#   |  |     +--ro revision     union
+#   |  |     +--ro namespace    inet:uri
+#   |  |     +--ro location*    inet:uri
+#   |  |     +--ro submodule* [name]
+#   |  |        +--ro name        yang:yang-identifier
+#   |  |        +--ro revision?   revision-identifier
+#   |  |        +--ro location*   inet:uri
+#   |  +--ro schema* [name]
+#   |  |  +--ro name          string
+#   |  |  +--ro module-set*   -> ../../module-set/name
+#   |  +--ro datastore* [name]
+#   |  |  +--ro name      ds:datastore-ref
+#   |  |  +--ro schema    -> ../../schema/name
+#   |  +--ro content-id    string
+def test_netconf_yang_library_tree():
+    select = '<yang-library xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-library"/>'
+    xml = _get_test_with_filter(select)
+    _xml = xml
+    print(etree.tostring(_xml, pretty_print=True, encoding="unicode"))
+    contentid = _xml.find('./{*}yang-library/{*}content-id').text
+    expected = """
+<nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <yang-library xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-library">
+    <module-set>
+      <name>common</name>
+      <module>
+        <name>alphabet</name>
+        <revision>2023-01-01</revision>
+        <namespace>http://test.com/ns/yang/alphabet</namespace>
+      </module>
+      <module>
+        <name>example</name>
+        <revision>2023-04-04</revision>
+        <namespace>http://example.com/ns/interfaces</namespace>
+        <feature>ether</feature>
+        <feature>fast</feature>
+        <deviation>user-example-deviation</deviation>
+      </module>
+      <module>
+        <name>ietf-yang-library</name>
+        <revision>2019-01-04</revision>
+        <namespace>urn:ietf:params:xml:ns:yang:ietf-yang-library</namespace>
+      </module>
+      <module>
+        <name>logical-elements</name>
+        <revision>2024-04-04</revision>
+        <namespace>http://example.com/ns/logical-elements</namespace>
+      </module>
+      <module>
+        <name>testing</name>
+        <revision>2023-01-01</revision>
+        <namespace>http://test.com/ns/yang/testing</namespace>
+        <feature>dummy</feature>
+        <feature>test-time</feature>
+      </module>
+      <module>
+        <name>testing-2</name>
+        <revision>2023-02-01</revision>
+        <namespace>http://test.com/ns/yang/testing-2</namespace>
+      </module>
+      <module>
+        <name>testing-3</name>
+        <revision>2023-03-01</revision>
+        <namespace>http://test.com/ns/yang/testing-3</namespace>
+      </module>
+      <module>
+        <name>testing-4</name>
+        <revision>2024-02-01</revision>
+        <namespace>http://test.com/ns/yang/testing-4</namespace>
+      </module>
+      <module>
+        <name>testing2-augmented</name>
+        <revision>2023-02-02</revision>
+        <namespace>http://test.com/ns/yang/testing2-augmented</namespace>
+      </module>
+    </module-set>
+    <schema>
+      <name>common</name>
+      <module-set>common</module-set>
+    </schema>
+    <datastore>
+      <name>ietf-datastores:running</name>
+      <schema>common</schema>
+    </datastore>
+    <content-id>%s</content-id>
+  </yang-library>
+</nc:data>
+    """ % (contentid)
+    expected = toXML(expected)
+    assert diffXML(xml, expected) is None


### PR DESCRIPTION
The yang-library support code has been moved from the apteryx-rest repo to the apteryx-xml repo, so it can be used as shared code with netconf.

Model information for the hello message is now derived directly from the yang-library data in apteryx.

Removed the -s option for a supported model list.

The help message capabilities are now derived from the yang-library data.