### PR TITLE
Fix escaping of special characters in XML

### DIFF
--- a/data.c
+++ b/data.c
@@ -291,7 +291,7 @@ _sch_gnode_to_xml (sch_instance * instance, sch_node * schema, sch_ns *ns, xmlNo
             {
                 char *leaf_name = APTERYX_NAME (value_node);
                 xmlNode *list_data = xmlNewNode (NULL, BAD_CAST name);
-                xmlNodeSetContent (list_data, (const xmlChar *) leaf_name);
+                xmlAddChild (list_data, xmlNewText ((const xmlChar *) leaf_name));
                 sch_ns *sns = sch_node_ns (schema);
                 if (!pschema || !sch_ns_match (pschema, sns))
                 {
@@ -359,7 +359,7 @@ _sch_gnode_to_xml (sch_instance * instance, sch_node * schema, sch_ns *ns, xmlNo
                         if (!n)
                         {
                             xmlNode *key_data = xmlNewNode (NULL, BAD_CAST key->data);
-                            xmlNodeSetContent (key_data, (const xmlChar *) APTERYX_NAME (child));
+                            xmlAddChild (key_data, xmlNewText ((const xmlChar *) APTERYX_NAME (child)));
                             xmlAddPrevSibling (list_data->children, key_data);
                         }
                     }
@@ -432,7 +432,7 @@ _sch_gnode_to_xml (sch_instance * instance, sch_node * schema, sch_ns *ns, xmlNo
                 xmlFree (idref_href);
             }
 
-            xmlNodeSetContent (data, (const xmlChar *) value);
+            xmlAddChild (data, xmlNewText ((const xmlChar *) value));
             if (parent)
                 xmlAddChildList (parent, data);
             DEBUG ("%*s%s = %s\n", depth * 2, " ", APTERYX_NAME (node), value);

--- a/tests/test_get_subtree.py
+++ b/tests/test_get_subtree.py
@@ -938,3 +938,21 @@ def test_get_subtree_must_condition_false():
 </nc:data>
     """
     _get_test_with_filter(select, expected)
+
+
+def test_get_subtree_ampersand_in_value():
+    apteryx.set('/test/animals/animal/parrot/colour', 'black&white')
+    select = '<test xmlns="http://test.com/ns/yang/testing"><animals><animal><name>parrot</name><colour/></animal></animals></test>'
+    xml = _get_test_with_filter(select)
+    colour = xml.find('.//{*}colour')
+    assert colour is not None
+    assert colour.text == 'black&white'
+
+
+def test_get_subtree_double_ampersand_in_value():
+    apteryx.set('/test/animals/animal/parrot/colour', 'black&&white')
+    select = '<test xmlns="http://test.com/ns/yang/testing"><animals><animal><name>parrot</name><colour/></animal></animals></test>'
+    xml = _get_test_with_filter(select)
+    colour = xml.find('.//{*}colour')
+    assert colour is not None
+    assert colour.text == 'black&&white'


### PR DESCRIPTION
The routine used to create the XML tree containing the required response was actually parsing & sequences. Replace with routine that just puts raw text in. This means that when the XML tree is actually serialised, we won't have lost the &s.